### PR TITLE
Private Key Bytes for signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,6 +1423,7 @@ name = "pshenmic_dpp_private_key"
 version = "0.1.0"
 dependencies = [
  "dpp",
+ "pshenmic_dpp_enums",
  "wasm-bindgen",
 ]
 

--- a/packages/enums/src/lib.rs
+++ b/packages/enums/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod batch;
 pub mod keys;
+pub mod network;
 pub mod platform;

--- a/packages/enums/src/network/mod.rs
+++ b/packages/enums/src/network/mod.rs
@@ -1,0 +1,33 @@
+use dpp::dashcore::Network;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(js_name = "Network")]
+pub enum NetworkWASM {
+    Dash,
+    Testnet,
+    Devnet,
+    Regtest,
+}
+
+impl From<Network> for NetworkWASM {
+    fn from(value: Network) -> Self {
+        match value {
+            Network::Dash => NetworkWASM::Dash,
+            Network::Testnet => NetworkWASM::Testnet,
+            Network::Devnet => NetworkWASM::Devnet,
+            Network::Regtest => NetworkWASM::Regtest,
+            _ => NetworkWASM::Testnet,
+        }
+    }
+}
+
+impl From<NetworkWASM> for Network {
+    fn from(value: NetworkWASM) -> Self {
+        match value {
+            NetworkWASM::Dash => Network::Dash,
+            NetworkWASM::Testnet => Network::Testnet,
+            NetworkWASM::Devnet => Network::Devnet,
+            NetworkWASM::Regtest => Network::Regtest,
+        }
+    }
+}

--- a/packages/private_key/Cargo.toml
+++ b/packages/private_key/Cargo.toml
@@ -11,6 +11,8 @@ wasm-bindgen = { version = "=0.2.100", features = ["serde-serialize"] }
 dpp = { git = "https://github.com/dashpay/platform", branch = "master", default-features = false, features = [
     "identity-value-conversion",
 ]}
+pshenmic_dpp_enums = {path = "../enums"}
+
 
 [profile.release]
 lto = true

--- a/packages/private_key/src/lib.rs
+++ b/packages/private_key/src/lib.rs
@@ -1,4 +1,5 @@
 use dpp::dashcore::PrivateKey;
+use pshenmic_dpp_enums::network::NetworkWASM;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -16,17 +17,25 @@ impl PrivateKeyWASM {
             Err(err) => Err(err),
         }
     }
-}
 
-#[wasm_bindgen]
-impl PrivateKeyWASM {
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(bytes: Vec<u8>, network: NetworkWASM) -> Result<Self, JsValue> {
+        let pk = PrivateKey::from_slice(bytes.as_slice(), network.into())
+            .map_err(|err| JsValue::from_str(&*err.to_string()));
+
+        match pk {
+            Ok(pk) => Ok(PrivateKeyWASM(pk)),
+            Err(err) => Err(err),
+        }
+    }
+
     #[wasm_bindgen(js_name = "getKeyWIF")]
-    pub fn get_key_wif(&self) -> String {
+    pub fn to_wif(&self) -> String {
         self.0.to_wif()
     }
 
-    #[wasm_bindgen(js_name = "getKeyBytes")]
-    pub fn get_key_bytes(&self) -> Vec<u8> {
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes()
     }
 }

--- a/packages/state_transition/src/lib.rs
+++ b/packages/state_transition/src/lib.rs
@@ -34,7 +34,37 @@ impl StateTransitionWASM {
     ) -> Result<JsValue, JsValue> {
         let sig = self.0.sign(
             &public_key.into(),
-            private_key.get_key_bytes().as_slice(),
+            private_key.to_bytes().as_slice(),
+            &MockBLS {},
+        );
+
+        let bytes = match sig {
+            Ok(_sig) => {
+                self.0.set_signature(self.0.signature().clone());
+                self.0
+                    .set_signature_public_key_id(self.0.signature_public_key_id().unwrap());
+                self.0.serialize_to_bytes()
+            }
+            Err(e) => wasm_bindgen::throw_str(&e.to_string()),
+        };
+
+        match bytes {
+            Ok(bytes) => Ok(JsValue::from(bytes.clone())),
+            Err(e) => Ok(JsValue::from_str(&format!("{}", e))),
+        }
+    }
+
+    #[wasm_bindgen(js_name=signByBytes)]
+    pub fn sign_by_bytes(
+        &mut self,
+        private_key_bytes: Vec<u8>,
+        public_key_bytes: Vec<u8>,
+    ) -> Result<JsValue, JsValue> {
+        let public_key = IdentityPublicKeyWASM::from_bytes(public_key_bytes)?;
+
+        let sig = self.0.sign(
+            &public_key.into(),
+            private_key_bytes.as_slice(),
             &MockBLS {},
         );
 
@@ -63,7 +93,30 @@ impl StateTransitionWASM {
         let _sig = self
             .0
             .sign_by_private_key(
-                &private_key.get_key_bytes().as_slice(),
+                &private_key.to_bytes().as_slice(),
+                KeyType::from(key_type),
+                &MockBLS {},
+            )
+            .with_js_error();
+
+        let bytes = self.0.serialize_to_bytes().with_js_error();
+
+        match bytes {
+            Ok(bytes) => JsValue::from(bytes.clone()),
+            Err(err) => err,
+        }
+    }
+
+    #[wasm_bindgen(js_name=signByPrivateKeyBytes)]
+    pub fn sign_by_private_key_bytes(
+        &mut self,
+        private_key_bytes: Vec<u8>,
+        key_type: KeyTypeWASM,
+    ) -> JsValue {
+        let _sig = self
+            .0
+            .sign_by_private_key(
+                &private_key_bytes.as_slice(),
                 KeyType::from(key_type),
                 &MockBLS {},
             )

--- a/packages/state_transition/src/lib.rs
+++ b/packages/state_transition/src/lib.rs
@@ -58,10 +58,8 @@ impl StateTransitionWASM {
     pub fn sign_by_bytes(
         &mut self,
         private_key_bytes: Vec<u8>,
-        public_key_bytes: Vec<u8>,
+        public_key: IdentityPublicKeyWASM,
     ) -> Result<JsValue, JsValue> {
-        let public_key = IdentityPublicKeyWASM::from_bytes(public_key_bytes)?;
-
         let sig = self.0.sign(
             &public_key.into(),
             private_key_bytes.as_slice(),
@@ -85,38 +83,11 @@ impl StateTransitionWASM {
     }
 
     #[wasm_bindgen(js_name=signByPrivateKey)]
-    pub fn sign_by_private_key(
-        &mut self,
-        private_key: PrivateKeyWASM,
-        key_type: KeyTypeWASM,
-    ) -> JsValue {
+    pub fn sign_by_private_key(&mut self, private_key: Vec<u8>, key_type: KeyTypeWASM) -> JsValue {
         let _sig = self
             .0
             .sign_by_private_key(
-                &private_key.to_bytes().as_slice(),
-                KeyType::from(key_type),
-                &MockBLS {},
-            )
-            .with_js_error();
-
-        let bytes = self.0.serialize_to_bytes().with_js_error();
-
-        match bytes {
-            Ok(bytes) => JsValue::from(bytes.clone()),
-            Err(err) => err,
-        }
-    }
-
-    #[wasm_bindgen(js_name=signByPrivateKeyBytes)]
-    pub fn sign_by_private_key_bytes(
-        &mut self,
-        private_key_bytes: Vec<u8>,
-        key_type: KeyTypeWASM,
-    ) -> JsValue {
-        let _sig = self
-            .0
-            .sign_by_private_key(
-                &private_key_bytes.as_slice(),
+                &private_key.as_slice(),
                 KeyType::from(key_type),
                 &MockBLS {},
             )


### PR DESCRIPTION
# Issue
We need method to sign transition by private key bytes

# Things done
- Implemented new 2 methods to sign by bytes
- Implemented `fromBytes` for PrivateKey
- Added `Network` enum