### PR TITLE
Data Contract new methods, new constructor and tiny renaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,7 @@ name = "pshenmic_dpp_data_contract"
 version = "0.1.0"
 dependencies = [
  "dpp",
+ "js-sys",
  "pshenmic_dpp_enums",
  "pshenmic_dpp_utils",
  "serde-wasm-bindgen",

--- a/packages/data_contract/Cargo.toml
+++ b/packages/data_contract/Cargo.toml
@@ -14,4 +14,5 @@ dpp = { git = "https://github.com/dashpay/platform", branch = "master", default-
     "data-contract-json-conversion",
     "platform-value"
 ]}
+js-sys = "0.3.53"
 serde-wasm-bindgen = { git = "https://github.com/QuantumExplorer/serde-wasm-bindgen", branch = "feat/not_human_readable" }

--- a/packages/data_contract/src/lib.rs
+++ b/packages/data_contract/src/lib.rs
@@ -1,18 +1,23 @@
 use dpp::dashcore::hashes::serde::Serialize;
 use dpp::data_contract::accessors::v0::{DataContractV0Getters, DataContractV0Setters};
+use dpp::data_contract::config::DataContractConfig;
 use dpp::data_contract::conversion::json::DataContractJsonConversionMethodsV0;
 use dpp::data_contract::conversion::value::v0::DataContractValueConversionMethodsV0;
 use dpp::data_contract::document_type::DocumentTypeRef;
 use dpp::data_contract::errors::DataContractError;
 use dpp::data_contract::schema::DataContractSchemaMethodsV0;
 use dpp::data_contract::{DataContract, DataContractV0};
+use dpp::platform_value::string_encoding::Encoding::Base58;
+use dpp::platform_value::{Value, ValueMap};
 use dpp::prelude::IdentityNonce;
 use dpp::serialization::{
     PlatformDeserializableWithPotentialValidationFromVersionedStructure,
     PlatformSerializableWithPlatformVersion,
 };
+use dpp::version::PlatformVersion;
 use pshenmic_dpp_enums::platform::PlatformVersionWASM;
 use pshenmic_dpp_utils::{ToSerdeJSONExt, WithJsError, identifier_from_js_value};
+use std::collections::BTreeMap;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -35,7 +40,87 @@ impl From<DataContractWASM> for DataContract {
 #[wasm_bindgen]
 impl DataContractWASM {
     #[wasm_bindgen(constructor)]
-    pub fn new(
+    pub fn from_js_values(
+        js_owner_id: JsValue,
+        identity_nonce: IdentityNonce,
+        js_schema: JsValue,
+        js_definitions: Option<js_sys::Object>,
+        js_platform_version: Option<PlatformVersionWASM>,
+    ) -> Result<DataContractWASM, JsValue> {
+        let serializer = serde_wasm_bindgen::Serializer::json_compatible();
+
+        let owner_id = identifier_from_js_value(&js_owner_id)?;
+
+        let owner_id_value = Value::from(owner_id.to_string(Base58));
+
+        let schema: Value = serde_wasm_bindgen::from_value(js_schema)?;
+
+        let platform_version =
+            PlatformVersion::from(js_platform_version.unwrap_or(PlatformVersionWASM::PLATFORM_V1));
+
+        let data_contract_structure_version_value = Value::from(
+            platform_version
+                .dpp
+                .contract_versions
+                .contract_structure_version
+                .to_string(),
+        );
+
+        let definitions = js_definitions
+            .map(|definitions| serde_wasm_bindgen::from_value(definitions.into()))
+            .transpose()?;
+
+        let definitions_value = Value::from(definitions);
+
+        let data_contract_id = DataContract::generate_data_contract_id_v0(owner_id, identity_nonce);
+
+        let data_contract_id_value = Value::from(data_contract_id.to_string(Base58));
+
+        let config =
+            DataContractConfig::default_for_version(&platform_version.clone()).with_js_error()?;
+
+        let config_value = config
+            .serialize(&serializer)
+            .map_err(JsValue::from)?
+            .with_serde_to_platform_value_map()?;
+
+        let mut contract_value = Value::Map(ValueMap::new());
+
+        contract_value
+            .set_value("$format_version", data_contract_structure_version_value)
+            .map_err(|err| JsValue::from(err.to_string()))?;
+
+        contract_value
+            .set_value("id", data_contract_id_value)
+            .map_err(|err| JsValue::from(err.to_string()))?;
+
+        contract_value
+            .set_value("config", Value::from(config_value))
+            .map_err(|err| JsValue::from(err.to_string()))?;
+
+        contract_value
+            .set_value("version", Value::from(1u16))
+            .map_err(|err| JsValue::from(err.to_string()))?;
+
+        contract_value
+            .set_value("ownerId", owner_id_value)
+            .map_err(|err| JsValue::from(err.to_string()))?;
+
+        contract_value
+            .set_value("schemaDefs", definitions_value)
+            .map_err(|err| JsValue::from(err.to_string()))?;
+
+        contract_value
+            .set_value("documentSchemas", schema)
+            .map_err(|err| JsValue::from(err.to_string()))?;
+
+        Ok(DataContractWASM(
+            DataContract::from_value(contract_value, true, &platform_version).with_js_error()?,
+        ))
+    }
+
+    #[wasm_bindgen(js_name = "fromValue")]
+    pub fn from_value(
         js_value: JsValue,
         full_validation: bool,
         platform_version: PlatformVersionWASM,
@@ -96,7 +181,7 @@ impl DataContractWASM {
             .map_err(JsValue::from)
     }
 
-    #[wasm_bindgen(js_name = "getDataContractVersion")]
+    #[wasm_bindgen(js_name = "getVersion")]
     pub fn get_data_contract_version(&self) -> u32 {
         self.0.version()
     }
@@ -119,6 +204,74 @@ impl DataContractWASM {
             .map_err(JsValue::from)
     }
 
+    #[wasm_bindgen(js_name = "setId")]
+    pub fn set_id(&mut self, js_data_contract_id: JsValue) -> Result<(), JsValue> {
+        let data_contract_id = identifier_from_js_value(&js_data_contract_id)?;
+
+        Ok(self.0.set_id(data_contract_id))
+    }
+
+    #[wasm_bindgen(js_name = "setOwnerId")]
+    pub fn set_owner_id(&mut self, js_owner_id: JsValue) -> Result<(), JsValue> {
+        let owner_id = identifier_from_js_value(&js_owner_id)?;
+
+        Ok(self.0.set_owner_id(owner_id))
+    }
+
+    #[wasm_bindgen(js_name = "setVersion")]
+    pub fn set_version(&mut self, version: u32) {
+        self.0.set_version(version)
+    }
+
+    #[wasm_bindgen(js_name = "setConfig")]
+    pub fn set_config(
+        &mut self,
+        js_config: JsValue,
+        js_platform_version: Option<PlatformVersionWASM>,
+    ) -> Result<(), JsValue> {
+        let platform_version =
+            PlatformVersion::from(js_platform_version.unwrap_or(PlatformVersionWASM::PLATFORM_V1));
+
+        let config_value: Value = serde_wasm_bindgen::from_value(js_config)?;
+
+        let config =
+            DataContractConfig::from_value(config_value, &platform_version).with_js_error()?;
+
+        self.0.set_config(config);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = "setSchema")]
+    pub fn set_schemas(
+        &mut self,
+        js_schema: JsValue,
+        js_definitions: Option<js_sys::Object>,
+        full_validation: bool,
+        js_platform_version: Option<PlatformVersionWASM>,
+    ) -> Result<(), JsValue> {
+        let platform_version =
+            PlatformVersion::from(js_platform_version.unwrap_or(PlatformVersionWASM::PLATFORM_V1));
+
+        let schema = js_schema.with_serde_to_platform_value_map()?;
+
+        let definitions: Option<BTreeMap<String, Value>> = js_definitions
+            .map(|definitions| serde_wasm_bindgen::from_value(definitions.into()))
+            .transpose()?;
+
+        self.0
+            .set_document_schemas(
+                schema,
+                definitions,
+                full_validation,
+                &mut Vec::new(),
+                &platform_version,
+            )
+            .with_js_error()?;
+
+        Ok(())
+    }
+
     #[wasm_bindgen(js_name = "toJson")]
     pub fn to_json(&self, platform_version: PlatformVersionWASM) -> Result<JsValue, JsValue> {
         let json = self.0.to_json(&platform_version.into()).with_js_error()?;
@@ -135,20 +288,6 @@ impl DataContractWASM {
         let owner_id = identifier_from_js_value(&js_owner_id)?;
 
         Ok(DataContract::generate_data_contract_id_v0(owner_id, identity_nonce).to_vec())
-    }
-
-    #[wasm_bindgen(js_name = "setId")]
-    pub fn set_id(&mut self, js_data_contract_id: JsValue) -> Result<(), JsValue> {
-        let data_contract_id = identifier_from_js_value(&js_data_contract_id)?;
-
-        Ok(self.0.set_id(data_contract_id))
-    }
-
-    #[wasm_bindgen(js_name = "setOwnerId")]
-    pub fn set_owner_id(&mut self, js_owner_id: JsValue) -> Result<(), JsValue> {
-        let owner_id = identifier_from_js_value(&js_owner_id)?;
-
-        Ok(self.0.set_owner_id(owner_id))
     }
 }
 

--- a/packages/data_contract/src/lib.rs
+++ b/packages/data_contract/src/lib.rs
@@ -45,6 +45,7 @@ impl DataContractWASM {
         identity_nonce: IdentityNonce,
         js_schema: JsValue,
         js_definitions: Option<js_sys::Object>,
+        full_validation: bool,
         js_platform_version: Option<PlatformVersionWASM>,
     ) -> Result<DataContractWASM, JsValue> {
         let serializer = serde_wasm_bindgen::Serializer::json_compatible();
@@ -115,7 +116,8 @@ impl DataContractWASM {
             .map_err(|err| JsValue::from(err.to_string()))?;
 
         Ok(DataContractWASM(
-            DataContract::from_value(contract_value, true, &platform_version).with_js_error()?,
+            DataContract::from_value(contract_value, full_validation, &platform_version)
+                .with_js_error()?,
         ))
     }
 
@@ -171,7 +173,7 @@ impl DataContractWASM {
             .map_err(JsValue::from)
     }
 
-    #[wasm_bindgen(js_name = "getSchemas")]
+    #[wasm_bindgen(js_name = "getSchema")]
     pub fn get_schemas(&self) -> Result<JsValue, JsValue> {
         let serializer = serde_wasm_bindgen::Serializer::json_compatible();
 
@@ -182,7 +184,7 @@ impl DataContractWASM {
     }
 
     #[wasm_bindgen(js_name = "getVersion")]
-    pub fn get_data_contract_version(&self) -> u32 {
+    pub fn get_version(&self) -> u32 {
         self.0.version()
     }
 

--- a/tests/DataContract.spec.js
+++ b/tests/DataContract.spec.js
@@ -18,20 +18,20 @@ describe('DataContract', function () {
   })
 
   describe('serialization / deserialization', function () {
-    it('should allows to create DataContract from value without full validation', function () {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+    it('should allows to create DataContract from schema without full validation', function () {
+      const dataContract = new wasm.DataContractWASM(value.ownerId, BigInt(2), value.documentSchemas, null, false)
 
       assert.notEqual(dataContract.__wbg_ptr, 0)
     })
 
-    it('should allows to create DataContract from value with full validation', function () {
-      const dataContract = new wasm.DataContractWASM(value, true, PlatformVersionWASM.PLATFORM_V1)
+    it('should allows to create DataContract from schema with full validation', function () {
+      const dataContract = new wasm.DataContractWASM(value.ownerId, BigInt(2), value.documentSchemas, null, true)
 
       assert.notEqual(dataContract.__wbg_ptr, 0)
     })
 
     it('should allows to create DataContract from value with full validation and without platform version', function () {
-      const dataContract = new wasm.DataContractWASM(value, true)
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
 
       assert.notEqual(dataContract.__wbg_ptr, 0)
     })
@@ -39,7 +39,7 @@ describe('DataContract', function () {
     it('should allows to convert DataContract to bytes and from bytes', function () {
       const [dataContractBytes] = dataContractsBytes
 
-      const dataContract = new wasm.DataContractWASM(value, true)
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
 
       assert.deepEqual(dataContract.toBytes(), fromHexString(dataContractBytes))
 
@@ -54,7 +54,7 @@ describe('DataContract', function () {
       const [dataContractBytes] = dataContractsBytes
 
       const dataContractFromBytes = wasm.DataContractWASM.fromBytes(fromHexString(dataContractBytes), false, PlatformVersionWASM.PLATFORM_V1)
-      const dataContractFromValue = new wasm.DataContractWASM(value, true)
+      const dataContractFromValue = wasm.DataContractWASM.fromValue(value, true)
 
       assert.deepEqual(dataContractFromBytes.toValue(), dataContractFromValue.toValue())
     })
@@ -63,13 +63,13 @@ describe('DataContract', function () {
       const [dataContractBytes] = dataContractsBytes
 
       const dataContractFromBytes = wasm.DataContractWASM.fromBytes(fromHexString(dataContractBytes), true)
-      const dataContractFromValue = new wasm.DataContractWASM(value, true)
+      const dataContractFromValue = wasm.DataContractWASM.fromValue(value, true)
 
       assert.deepEqual(dataContractFromBytes.toValue(), dataContractFromValue.toValue())
     })
 
     it('should allow to get json', function () {
-      const dataContract = new wasm.DataContractWASM(value, true)
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
 
       assert.deepEqual(dataContract.toJson(), value)
     })
@@ -77,31 +77,31 @@ describe('DataContract', function () {
 
   describe('getters', function () {
     it('should allow to get schemas', function () {
-      const dataContract = new wasm.DataContractWASM(value, true)
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
 
-      assert.deepEqual(dataContract.getSchemas(), value.documentSchemas)
+      assert.deepEqual(dataContract.getSchema(), value.documentSchemas)
     })
 
     it('should allow to get version', function () {
-      const dataContract = new wasm.DataContractWASM(value, true)
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
 
-      assert.deepEqual(dataContract.getDataContractVersion(), value.version)
+      assert.deepEqual(dataContract.getVersion(), value.version)
     })
 
     it('should allow to get id', function () {
-      const dataContract = new wasm.DataContractWASM(value, true)
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
 
       assert.deepEqual(dataContract.getId(), base58.decode(id))
     })
 
     it('should allow to get owner id', function () {
-      const dataContract = new wasm.DataContractWASM(value, true)
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
 
       assert.deepEqual(dataContract.getOwnerId(), base58.decode(ownerId))
     })
 
     it('should allow to get config', function () {
-      const dataContract = new wasm.DataContractWASM(value, true)
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
 
       assert.deepEqual(dataContract.getConfig(), value.config)
     })
@@ -109,7 +109,7 @@ describe('DataContract', function () {
 
   describe('setters', function () {
     it('should allow to set id', function () {
-      const dataContract = new wasm.DataContractWASM(value, true)
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
 
       const valueId = base58.decode('7ckT6Y19HnjfqoPFmfL995i4z2HwgZ8UttNmP99LtCBH')
 
@@ -119,13 +119,47 @@ describe('DataContract', function () {
     })
 
     it('should allow to set owner id', function () {
-      const dataContract = new wasm.DataContractWASM(value, true)
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
 
       const valueId = base58.decode('3bx13Wd5k4LwHAvXJrayc5HdKPyiccKWYECPQGGYfnVL')
 
       dataContract.setOwnerId('3bx13Wd5k4LwHAvXJrayc5HdKPyiccKWYECPQGGYfnVL')
 
       assert.deepEqual(dataContract.getOwnerId(), valueId)
+    })
+
+    it('should allow to set version', function () {
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
+
+      dataContract.setVersion(20)
+
+      assert.equal(dataContract.getVersion(), 20)
+    })
+
+    it('should allow to set config', function () {
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
+
+      const oldConfig = dataContract.getConfig()
+
+      const newConfig = { ...oldConfig, canBeDeleted: !oldConfig.canBeDeleted }
+
+      dataContract.setConfig(newConfig)
+
+      assert.deepEqual(dataContract.getConfig(), newConfig)
+    })
+
+    it('should allow to set schema', function () {
+      const dataContract = wasm.DataContractWASM.fromValue(value, true)
+
+      const oldSchema = dataContract.getSchema()
+
+      const newSchema = {
+        pupup: oldSchema.withdrawal
+      }
+
+      dataContract.setSchema(newSchema)
+
+      assert.deepEqual(dataContract.getSchema(), newSchema)
     })
   })
 

--- a/tests/DataContractCreateStateTransition.spec.js
+++ b/tests/DataContractCreateStateTransition.spec.js
@@ -14,7 +14,7 @@ describe('DataContract Create Transition', function () {
 
   describe('serialization / deserialization', function () {
     it('should allow to create transitions from data contract', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractCreateTransitionWASM(dataContract, BigInt(1))
 
@@ -23,7 +23,7 @@ describe('DataContract Create Transition', function () {
     })
 
     it('should allow to convert transitions to bytes and create from bytes', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractCreateTransitionWASM(dataContract, BigInt(1))
 
@@ -38,7 +38,7 @@ describe('DataContract Create Transition', function () {
     })
 
     it('should allow to convert data contract transition to state transitions and create data contract transition from state transition', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractCreateTransitionWASM(dataContract, BigInt(1))
 
@@ -52,7 +52,7 @@ describe('DataContract Create Transition', function () {
 
   describe('getters', function () {
     it('should allow to get feature version', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractCreateTransitionWASM(dataContract, BigInt(1))
 
@@ -60,7 +60,7 @@ describe('DataContract Create Transition', function () {
     })
 
     it('should allow to verify protocol version', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractCreateTransitionWASM(dataContract, BigInt(1))
 
@@ -68,7 +68,7 @@ describe('DataContract Create Transition', function () {
     })
 
     it('should allow to verify incorrect protocol version', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractCreateTransitionWASM(dataContract, BigInt(1))
 
@@ -81,7 +81,7 @@ describe('DataContract Create Transition', function () {
     })
 
     it('should allow to get data contract', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractCreateTransitionWASM(dataContract, BigInt(1))
 
@@ -95,7 +95,7 @@ describe('DataContract Create Transition', function () {
     it('should allow to set the data contract', () => {
       const [dataContractBytes] = dataContractsBytes
 
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractCreateTransitionWASM(dataContract, BigInt(1))
 

--- a/tests/DataContractUpdateStateTransition.spec.js
+++ b/tests/DataContractUpdateStateTransition.spec.js
@@ -14,7 +14,7 @@ describe('DataContract Updatet Transition', function () {
 
   describe('serialization / deserialization', function () {
     it('should allow to create transitions from data contract', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractUpdateTransitionWASM(dataContract, BigInt(1))
 
@@ -23,7 +23,7 @@ describe('DataContract Updatet Transition', function () {
     })
 
     it('should allow to convert transitions to bytes and create from bytes', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractUpdateTransitionWASM(dataContract, BigInt(1))
 
@@ -38,7 +38,7 @@ describe('DataContract Updatet Transition', function () {
     })
 
     it('should allow to convert data contract transition to state transitions and create data contract transition from state transition', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractUpdateTransitionWASM(dataContract, BigInt(1))
 
@@ -52,7 +52,7 @@ describe('DataContract Updatet Transition', function () {
 
   describe('getters', function () {
     it('should allow to get feature version', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractUpdateTransitionWASM(dataContract, BigInt(1))
 
@@ -60,7 +60,7 @@ describe('DataContract Updatet Transition', function () {
     })
 
     it('should allow to verify protocol version', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractUpdateTransitionWASM(dataContract, BigInt(1))
 
@@ -68,7 +68,7 @@ describe('DataContract Updatet Transition', function () {
     })
 
     it('should allow to verify incorrect protocol version', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractUpdateTransitionWASM(dataContract, BigInt(1))
 
@@ -81,7 +81,7 @@ describe('DataContract Updatet Transition', function () {
     })
 
     it('should allow to get data contract', () => {
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractUpdateTransitionWASM(dataContract, BigInt(1))
 
@@ -95,7 +95,7 @@ describe('DataContract Updatet Transition', function () {
     it('should allow to set the data contract', () => {
       const [dataContractBytes] = dataContractsBytes
 
-      const dataContract = new wasm.DataContractWASM(value, false, PlatformVersionWASM.PLATFORM_V1)
+      const dataContract = wasm.DataContractWASM.fromValue(value, false, PlatformVersionWASM.PLATFORM_V1)
 
       const dataContractTransition = new wasm.DataContractUpdateTransitionWASM(dataContract, BigInt(1))
 

--- a/tests/Document.spec.js
+++ b/tests/Document.spec.js
@@ -28,7 +28,7 @@ describe('Document', function () {
     })
 
     it('should allows to create Document from bytes and convert to bytes', function () {
-      const dataContract = new wasm.DataContractWASM(dataContractValue, false)
+      const dataContract = wasm.DataContractWASM.fromValue(dataContractValue, false)
       const documentInstance = wasm.DocumentWASM.fromBytes(fromHexString(documentBytes), dataContract, 'note')
 
       const bytes = documentInstance.toBytes(dataContract, 'note')


### PR DESCRIPTION
# Issue
At this moment we generate data contracts via value, but we need to implement generation from schema
Also we don't have all getters and setters in class

# Things done
- Added implementation for new constructor, which allow to create DataContract Instance via: `owner_id`, `nonce`, `schema` and `definitions`
- Added new setters for data contract
- Renamed `getSchemas` -> `getSchema`
- Renamed `getDataContractVersion ` -> `getVersion`
- Implemented setters for `version`, `config` and `schema`
- Updated Tests
- Implemented tests for new constructor and setters