### PR TITLE
Private Key and Public Key types fixes

### DIFF
--- a/packages/identity_public_key/src/lib.rs
+++ b/packages/identity_public_key/src/lib.rs
@@ -169,7 +169,7 @@ impl IdentityPublicKeyWASM {
             .public_key_hash()
             .with_js_error()
             .map(|slice| slice.to_vec())?
-            .to_hex_string(Case::Upper);
+            .to_hex_string(Case::Lower);
 
         Ok(hash)
     }

--- a/packages/identity_public_key/src/lib.rs
+++ b/packages/identity_public_key/src/lib.rs
@@ -1,4 +1,5 @@
 use dpp::dashcore::Network;
+use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use dpp::identity::hash::IdentityPublicKeyHashMethodsV0;
 use dpp::identity::identity_public_key::accessors::v0::{
     IdentityPublicKeyGettersV0, IdentityPublicKeySettersV0,
@@ -162,11 +163,15 @@ impl IdentityPublicKeyWASM {
     }
 
     #[wasm_bindgen(js_name = "getPublicKeyHash")]
-    pub fn public_key_hash(&self) -> Result<Vec<u8>, JsValue> {
-        self.0
+    pub fn public_key_hash(&self) -> Result<String, JsValue> {
+        let hash = self
+            .0
             .public_key_hash()
             .with_js_error()
-            .map(|slice| slice.to_vec())
+            .map(|slice| slice.to_vec())?
+            .to_hex_string(Case::Upper);
+
+        Ok(hash)
     }
 
     #[wasm_bindgen(js_name = toBytes)]

--- a/tests/IdentityPublicKey.spec.js
+++ b/tests/IdentityPublicKey.spec.js
@@ -6,6 +6,7 @@ const {
   keyTypeSet, binaryDataSet
 } = require('./mocks/PublicKey')
 const { wif } = require('./mocks/PrivateKey')
+const { toHexString } = require('./utils/hex')
 
 let wasm
 
@@ -67,7 +68,7 @@ describe('PublicKey', function () {
 
       const hash = pubKey.getPublicKeyHash()
 
-      assert.deepEqual(hash, Uint8Array.from([211, 114, 240, 150, 37, 159, 114, 104, 110, 24, 102, 61, 125, 181, 248, 98, 52, 221, 111, 85]))
+      assert.deepEqual(hash.toLowerCase(), toHexString([211, 114, 240, 150, 37, 159, 114, 104, 110, 24, 102, 61, 125, 181, 248, 98, 52, 221, 111, 85]))
     })
   })
   describe('getters', function () {

--- a/tests/IdentityPublicKey.spec.js
+++ b/tests/IdentityPublicKey.spec.js
@@ -68,7 +68,7 @@ describe('PublicKey', function () {
 
       const hash = pubKey.getPublicKeyHash()
 
-      assert.deepEqual(hash.toLowerCase(), toHexString([211, 114, 240, 150, 37, 159, 114, 104, 110, 24, 102, 61, 125, 181, 248, 98, 52, 221, 111, 85]))
+      assert.deepEqual(hash, toHexString([211, 114, 240, 150, 37, 159, 114, 104, 110, 24, 102, 61, 125, 181, 248, 98, 52, 221, 111, 85]))
     })
   })
   describe('getters', function () {

--- a/tests/PrivateKey.spec.js
+++ b/tests/PrivateKey.spec.js
@@ -24,6 +24,14 @@ describe('PrivateKey', function () {
       assert.notEqual(pkey.__wbg_ptr, 0)
     })
 
+    it('should allows to create PrivateKey from hex', function () {
+      const pkey = wasm.PrivateKeyWASM.fromBytes(fromHexString(bytes), 'Mainnet')
+
+      const pkeyFromHex = wasm.PrivateKeyWASM.fromHex(bytes, 'Mainnet')
+
+      assert.deepEqual(pkey.getBytes(), pkeyFromHex.getBytes())
+    })
+
     it('should allow to create PrivateKey from wif and read value in wif', function () {
       const pkey = wasm.PrivateKeyWASM.fromWIF(wif)
 
@@ -48,6 +56,12 @@ describe('PrivateKey', function () {
       const pkey = wasm.PrivateKeyWASM.fromWIF(wif)
 
       assert.equal(toHexString(pkey.getBytes()), bytes)
+    })
+
+    it('should allow to get key hex', function () {
+      const pkey = wasm.PrivateKeyWASM.fromWIF(wif)
+
+      assert.equal(pkey.getHex().toLowerCase(), bytes)
     })
 
     it('should allow to get public key hash', function () {


### PR DESCRIPTION
# Issue
We need to implement serialization and deserialization from hex for PrivateKey and retunrs string for hash from IdentityPublickKey

# Things done
- Implemented new methods for `PrivateKeyWASM`
- Updated type for method `getPublicKeyHash` for `IdentityPublicKey`
- Updated tests