### PR TITLE
Case insensetive for enums

### DIFF
--- a/packages/enums/src/keys/key_type.rs
+++ b/packages/enums/src/keys/key_type.rs
@@ -24,7 +24,7 @@ impl TryFrom<JsValue> for KeyTypeWASM {
                     "ecdsa_hash160" => Ok(KeyTypeWASM::ECDSA_HASH160),
                     "bip13_script_hash" => Ok(KeyTypeWASM::BIP13_SCRIPT_HASH),
                     "eddsa_25519_hash160" => Ok(KeyTypeWASM::EDDSA_25519_HASH160),
-                    _ => Err(JsValue::from("unsupported key type")),
+                    _ => Err(JsValue::from("unsupported enum value")),
                 },
             },
             false => match value.as_f64() {
@@ -35,7 +35,7 @@ impl TryFrom<JsValue> for KeyTypeWASM {
                     2 => Ok(KeyTypeWASM::ECDSA_HASH160),
                     3 => Ok(KeyTypeWASM::BIP13_SCRIPT_HASH),
                     4 => Ok(KeyTypeWASM::EDDSA_25519_HASH160),
-                    _ => Err(JsValue::from("unsupported key type")),
+                    _ => Err(JsValue::from("unsupported enum value")),
                 },
             },
         }

--- a/packages/enums/src/keys/key_type.rs
+++ b/packages/enums/src/keys/key_type.rs
@@ -18,12 +18,12 @@ impl TryFrom<JsValue> for KeyTypeWASM {
         match value.is_string() {
             true => match value.as_string() {
                 None => Err(JsValue::from("cannot read value from enum")),
-                Some(enum_val) => match enum_val.as_str() {
-                    "ECDSA_SECP256K1" => Ok(KeyTypeWASM::ECDSA_SECP256K1),
-                    "BLS12_381" => Ok(KeyTypeWASM::BLS12_381),
-                    "ECDSA_HASH160" => Ok(KeyTypeWASM::ECDSA_HASH160),
-                    "BIP13_SCRIPT_HASH" => Ok(KeyTypeWASM::BIP13_SCRIPT_HASH),
-                    "EDDSA_25519_HASH160" => Ok(KeyTypeWASM::EDDSA_25519_HASH160),
+                Some(enum_val) => match enum_val.to_lowercase().as_str() {
+                    "ecdsa_secp256k1" => Ok(KeyTypeWASM::ECDSA_SECP256K1),
+                    "bls12_381" => Ok(KeyTypeWASM::BLS12_381),
+                    "ecdsa_hash160" => Ok(KeyTypeWASM::ECDSA_HASH160),
+                    "bip13_script_hash" => Ok(KeyTypeWASM::BIP13_SCRIPT_HASH),
+                    "eddsa_25519_hash160" => Ok(KeyTypeWASM::EDDSA_25519_HASH160),
                     _ => Err(JsValue::from("unsupported key type")),
                 },
             },

--- a/packages/enums/src/keys/key_type.rs
+++ b/packages/enums/src/keys/key_type.rs
@@ -24,7 +24,7 @@ impl TryFrom<JsValue> for KeyTypeWASM {
                     "ecdsa_hash160" => Ok(KeyTypeWASM::ECDSA_HASH160),
                     "bip13_script_hash" => Ok(KeyTypeWASM::BIP13_SCRIPT_HASH),
                     "eddsa_25519_hash160" => Ok(KeyTypeWASM::EDDSA_25519_HASH160),
-                    _ => Err(JsValue::from("unsupported enum value")),
+                    _ => Err(JsValue::from(format!("unsupported key type {}", enum_val))),
                 },
             },
             false => match value.as_f64() {
@@ -35,7 +35,7 @@ impl TryFrom<JsValue> for KeyTypeWASM {
                     2 => Ok(KeyTypeWASM::ECDSA_HASH160),
                     3 => Ok(KeyTypeWASM::BIP13_SCRIPT_HASH),
                     4 => Ok(KeyTypeWASM::EDDSA_25519_HASH160),
-                    _ => Err(JsValue::from("unsupported enum value")),
+                    _ => Err(JsValue::from(format!("unsupported key type ({})", enum_val))),
                 },
             },
         }

--- a/packages/enums/src/keys/key_type.rs
+++ b/packages/enums/src/keys/key_type.rs
@@ -35,7 +35,10 @@ impl TryFrom<JsValue> for KeyTypeWASM {
                     2 => Ok(KeyTypeWASM::ECDSA_HASH160),
                     3 => Ok(KeyTypeWASM::BIP13_SCRIPT_HASH),
                     4 => Ok(KeyTypeWASM::EDDSA_25519_HASH160),
-                    _ => Err(JsValue::from(format!("unsupported key type ({})", enum_val))),
+                    _ => Err(JsValue::from(format!(
+                        "unsupported key type ({})",
+                        enum_val
+                    ))),
                 },
             },
         }

--- a/packages/enums/src/keys/purpose.rs
+++ b/packages/enums/src/keys/purpose.rs
@@ -19,14 +19,14 @@ impl TryFrom<JsValue> for PurposeWASM {
         match value.is_string() {
             true => match value.as_string() {
                 None => Err(JsValue::from("cannot read value from enum")),
-                Some(enum_val) => match enum_val.as_str() {
-                    "AUTHENTICATION" => Ok(PurposeWASM::AUTHENTICATION),
-                    "ENCRYPTION" => Ok(PurposeWASM::ENCRYPTION),
-                    "DECRYPTION" => Ok(PurposeWASM::DECRYPTION),
-                    "TRANSFER" => Ok(PurposeWASM::TRANSFER),
-                    "SYSTEM" => Ok(PurposeWASM::SYSTEM),
-                    "VOTING" => Ok(PurposeWASM::VOTING),
-                    "OWNER" => Ok(PurposeWASM::OWNER),
+                Some(enum_val) => match enum_val.to_lowercase().as_str() {
+                    "authentication" => Ok(PurposeWASM::AUTHENTICATION),
+                    "encryption" => Ok(PurposeWASM::ENCRYPTION),
+                    "decryption" => Ok(PurposeWASM::DECRYPTION),
+                    "transfer" => Ok(PurposeWASM::TRANSFER),
+                    "system" => Ok(PurposeWASM::SYSTEM),
+                    "voting" => Ok(PurposeWASM::VOTING),
+                    "owner" => Ok(PurposeWASM::OWNER),
                     _ => Err(JsValue::from("unsupported key type")),
                 },
             },

--- a/packages/enums/src/keys/purpose.rs
+++ b/packages/enums/src/keys/purpose.rs
@@ -27,7 +27,10 @@ impl TryFrom<JsValue> for PurposeWASM {
                     "system" => Ok(PurposeWASM::SYSTEM),
                     "voting" => Ok(PurposeWASM::VOTING),
                     "owner" => Ok(PurposeWASM::OWNER),
-                    _ => Err(JsValue::from(format!("unsupported purpose value ({})", enum_val))),
+                    _ => Err(JsValue::from(format!(
+                        "unsupported purpose value ({})",
+                        enum_val
+                    ))),
                 },
             },
             false => match value.as_f64() {
@@ -40,7 +43,10 @@ impl TryFrom<JsValue> for PurposeWASM {
                     4 => Ok(PurposeWASM::SYSTEM),
                     5 => Ok(PurposeWASM::VOTING),
                     6 => Ok(PurposeWASM::OWNER),
-                    _ => Err(JsValue::from(format!("unsupported purpose value ({})", enum_val))),
+                    _ => Err(JsValue::from(format!(
+                        "unsupported purpose value ({})",
+                        enum_val
+                    ))),
                 },
             },
         }

--- a/packages/enums/src/keys/purpose.rs
+++ b/packages/enums/src/keys/purpose.rs
@@ -27,7 +27,7 @@ impl TryFrom<JsValue> for PurposeWASM {
                     "system" => Ok(PurposeWASM::SYSTEM),
                     "voting" => Ok(PurposeWASM::VOTING),
                     "owner" => Ok(PurposeWASM::OWNER),
-                    _ => Err(JsValue::from("unsupported key type")),
+                    _ => Err(JsValue::from("unsupported enum value")),
                 },
             },
             false => match value.as_f64() {
@@ -40,7 +40,7 @@ impl TryFrom<JsValue> for PurposeWASM {
                     4 => Ok(PurposeWASM::SYSTEM),
                     5 => Ok(PurposeWASM::VOTING),
                     6 => Ok(PurposeWASM::OWNER),
-                    _ => Err(JsValue::from("unsupported key type")),
+                    _ => Err(JsValue::from("unsupported enum value")),
                 },
             },
         }

--- a/packages/enums/src/keys/purpose.rs
+++ b/packages/enums/src/keys/purpose.rs
@@ -1,4 +1,3 @@
-use std::fmt::format;
 use dpp::identity::Purpose;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;

--- a/packages/enums/src/keys/purpose.rs
+++ b/packages/enums/src/keys/purpose.rs
@@ -1,3 +1,4 @@
+use std::fmt::format;
 use dpp::identity::Purpose;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -27,7 +28,7 @@ impl TryFrom<JsValue> for PurposeWASM {
                     "system" => Ok(PurposeWASM::SYSTEM),
                     "voting" => Ok(PurposeWASM::VOTING),
                     "owner" => Ok(PurposeWASM::OWNER),
-                    _ => Err(JsValue::from("unsupported enum value")),
+                    _ => Err(JsValue::from(format!("unsupported purpose value ({})", enum_val))),
                 },
             },
             false => match value.as_f64() {
@@ -40,7 +41,7 @@ impl TryFrom<JsValue> for PurposeWASM {
                     4 => Ok(PurposeWASM::SYSTEM),
                     5 => Ok(PurposeWASM::VOTING),
                     6 => Ok(PurposeWASM::OWNER),
-                    _ => Err(JsValue::from("unsupported enum value")),
+                    _ => Err(JsValue::from(format!("unsupported purpose value ({})", enum_val))),
                 },
             },
         }

--- a/packages/enums/src/keys/security_level.rs
+++ b/packages/enums/src/keys/security_level.rs
@@ -21,7 +21,7 @@ impl TryFrom<JsValue> for SecurityLevelWASM {
                     "critical" => Ok(SecurityLevelWASM::CRITICAL),
                     "high" => Ok(SecurityLevelWASM::HIGH),
                     "medium" => Ok(SecurityLevelWASM::MEDIUM),
-                    _ => Err(JsValue::from("unsupported key type")),
+                    _ => Err(JsValue::from("unsupported enum value")),
                 },
             },
             false => match value.as_f64() {
@@ -31,7 +31,7 @@ impl TryFrom<JsValue> for SecurityLevelWASM {
                     1 => Ok(SecurityLevelWASM::CRITICAL),
                     2 => Ok(SecurityLevelWASM::HIGH),
                     3 => Ok(SecurityLevelWASM::MEDIUM),
-                    _ => Err(JsValue::from("unsupported key type")),
+                    _ => Err(JsValue::from("unsupported enum value")),
                 },
             },
         }

--- a/packages/enums/src/keys/security_level.rs
+++ b/packages/enums/src/keys/security_level.rs
@@ -21,7 +21,10 @@ impl TryFrom<JsValue> for SecurityLevelWASM {
                     "critical" => Ok(SecurityLevelWASM::CRITICAL),
                     "high" => Ok(SecurityLevelWASM::HIGH),
                     "medium" => Ok(SecurityLevelWASM::MEDIUM),
-                    _ => Err(JsValue::from(format!("unsupported security level value ({})", enum_val))),
+                    _ => Err(JsValue::from(format!(
+                        "unsupported security level value ({})",
+                        enum_val
+                    ))),
                 },
             },
             false => match value.as_f64() {
@@ -31,7 +34,10 @@ impl TryFrom<JsValue> for SecurityLevelWASM {
                     1 => Ok(SecurityLevelWASM::CRITICAL),
                     2 => Ok(SecurityLevelWASM::HIGH),
                     3 => Ok(SecurityLevelWASM::MEDIUM),
-                    _ => Err(JsValue::from(format!("unsupported security level value ({})", enum_val))),
+                    _ => Err(JsValue::from(format!(
+                        "unsupported security level value ({})",
+                        enum_val
+                    ))),
                 },
             },
         }

--- a/packages/enums/src/keys/security_level.rs
+++ b/packages/enums/src/keys/security_level.rs
@@ -16,11 +16,11 @@ impl TryFrom<JsValue> for SecurityLevelWASM {
         match value.is_string() {
             true => match value.as_string() {
                 None => Err(JsValue::from("cannot read value from enum")),
-                Some(enum_val) => match enum_val.as_str() {
-                    "MASTER" => Ok(SecurityLevelWASM::MASTER),
-                    "CRITICAL" => Ok(SecurityLevelWASM::CRITICAL),
-                    "HIGH" => Ok(SecurityLevelWASM::HIGH),
-                    "MEDIUM" => Ok(SecurityLevelWASM::MEDIUM),
+                Some(enum_val) => match enum_val.to_lowercase().as_str() {
+                    "master" => Ok(SecurityLevelWASM::MASTER),
+                    "critical" => Ok(SecurityLevelWASM::CRITICAL),
+                    "high" => Ok(SecurityLevelWASM::HIGH),
+                    "medium" => Ok(SecurityLevelWASM::MEDIUM),
                     _ => Err(JsValue::from("unsupported key type")),
                 },
             },

--- a/packages/enums/src/keys/security_level.rs
+++ b/packages/enums/src/keys/security_level.rs
@@ -21,7 +21,7 @@ impl TryFrom<JsValue> for SecurityLevelWASM {
                     "critical" => Ok(SecurityLevelWASM::CRITICAL),
                     "high" => Ok(SecurityLevelWASM::HIGH),
                     "medium" => Ok(SecurityLevelWASM::MEDIUM),
-                    _ => Err(JsValue::from("unsupported enum value")),
+                    _ => Err(JsValue::from(format!("unsupported security level value ({})", enum_val))),
                 },
             },
             false => match value.as_f64() {
@@ -31,7 +31,7 @@ impl TryFrom<JsValue> for SecurityLevelWASM {
                     1 => Ok(SecurityLevelWASM::CRITICAL),
                     2 => Ok(SecurityLevelWASM::HIGH),
                     3 => Ok(SecurityLevelWASM::MEDIUM),
-                    _ => Err(JsValue::from("unsupported enum value")),
+                    _ => Err(JsValue::from(format!("unsupported security level value ({})", enum_val))),
                 },
             },
         }

--- a/packages/enums/src/network/mod.rs
+++ b/packages/enums/src/network/mod.rs
@@ -21,7 +21,7 @@ impl TryFrom<JsValue> for NetworkWASM {
                     "testnet" => Ok(NetworkWASM::Testnet),
                     "devnet" => Ok(NetworkWASM::Devnet),
                     "regtest" => Ok(NetworkWASM::Regtest),
-                    _ => Err(JsValue::from("unsupported enum value")),
+                    _ => Err(JsValue::from(format!("unsupported network name ({})", enum_val))),
                 },
             },
             false => match value.as_f64() {
@@ -31,7 +31,7 @@ impl TryFrom<JsValue> for NetworkWASM {
                     1 => Ok(NetworkWASM::Testnet),
                     2 => Ok(NetworkWASM::Devnet),
                     3 => Ok(NetworkWASM::Regtest),
-                    _ => Err(JsValue::from("unsupported enum value")),
+                    _ => Err(JsValue::from(format!("unsupported network name ({})", enum_val))),
                 },
             },
         }

--- a/packages/enums/src/network/mod.rs
+++ b/packages/enums/src/network/mod.rs
@@ -21,7 +21,10 @@ impl TryFrom<JsValue> for NetworkWASM {
                     "testnet" => Ok(NetworkWASM::Testnet),
                     "devnet" => Ok(NetworkWASM::Devnet),
                     "regtest" => Ok(NetworkWASM::Regtest),
-                    _ => Err(JsValue::from(format!("unsupported network name ({})", enum_val))),
+                    _ => Err(JsValue::from(format!(
+                        "unsupported network name ({})",
+                        enum_val
+                    ))),
                 },
             },
             false => match value.as_f64() {
@@ -31,7 +34,10 @@ impl TryFrom<JsValue> for NetworkWASM {
                     1 => Ok(NetworkWASM::Testnet),
                     2 => Ok(NetworkWASM::Devnet),
                     3 => Ok(NetworkWASM::Regtest),
-                    _ => Err(JsValue::from(format!("unsupported network name ({})", enum_val))),
+                    _ => Err(JsValue::from(format!(
+                        "unsupported network name ({})",
+                        enum_val
+                    ))),
                 },
             },
         }

--- a/packages/enums/src/network/mod.rs
+++ b/packages/enums/src/network/mod.rs
@@ -16,11 +16,11 @@ impl TryFrom<JsValue> for NetworkWASM {
         match value.is_string() {
             true => match value.as_string() {
                 None => Err(JsValue::from("cannot read value from enum")),
-                Some(enum_val) => match enum_val.as_str() {
-                    "Mainnet" => Ok(NetworkWASM::Mainnet),
-                    "Testnet" => Ok(NetworkWASM::Testnet),
-                    "Devnet" => Ok(NetworkWASM::Devnet),
-                    "Regtest" => Ok(NetworkWASM::Regtest),
+                Some(enum_val) => match enum_val.to_lowercase().as_str() {
+                    "mainnet" => Ok(NetworkWASM::Mainnet),
+                    "testnet" => Ok(NetworkWASM::Testnet),
+                    "devnet" => Ok(NetworkWASM::Devnet),
+                    "regtest" => Ok(NetworkWASM::Regtest),
                     _ => Err(JsValue::from("unsupported key type")),
                 },
             },

--- a/packages/enums/src/network/mod.rs
+++ b/packages/enums/src/network/mod.rs
@@ -21,7 +21,7 @@ impl TryFrom<JsValue> for NetworkWASM {
                     "testnet" => Ok(NetworkWASM::Testnet),
                     "devnet" => Ok(NetworkWASM::Devnet),
                     "regtest" => Ok(NetworkWASM::Regtest),
-                    _ => Err(JsValue::from("unsupported key type")),
+                    _ => Err(JsValue::from("unsupported enum value")),
                 },
             },
             false => match value.as_f64() {
@@ -31,7 +31,7 @@ impl TryFrom<JsValue> for NetworkWASM {
                     1 => Ok(NetworkWASM::Testnet),
                     2 => Ok(NetworkWASM::Devnet),
                     3 => Ok(NetworkWASM::Regtest),
-                    _ => Err(JsValue::from("unsupported key type")),
+                    _ => Err(JsValue::from("unsupported enum value")),
                 },
             },
         }


### PR DESCRIPTION
# Issue
At this momment enums with string support cannot be created from any case, like testnet and Testnet and o.e.

# Things done
- Added `to_lower` before convertation
- Fixed error on invalid value