### PR TITLE
Auto versions bump for child packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_data_contract"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
  "js-sys",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_data_contract_transitions"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
  "pshenmic_dpp_data_contract",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_document"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
  "pshenmic_dpp_data_contract",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_document_search"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "base64",
  "ciborium 0.2.2",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_documents_batch"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
  "js-sys",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_enums"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
  "wasm-bindgen",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_identity"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
  "pshenmic_dpp_public_key",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_identity_transitions"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
  "pshenmic_dpp_enums",
@@ -1439,14 +1439,14 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_mock_bls"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
 ]
 
 [[package]]
 name = "pshenmic_dpp_private_key"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
  "pshenmic_dpp_enums",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_public_key"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
  "pshenmic_dpp_enums",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_state_transition"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "dpp",
  "pshenmic_dpp_enums",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic_dpp_utils"
-version = "0.1.0"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "dpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[package]
+name = "pshenmic-dpp"
+version = "1.0.4"
+edition = "2024"
+rust-version = "1.85"
+
 [workspace]
 resolver = "2"
 members = [
@@ -15,14 +21,11 @@ members = [
     "packages/data_contract"
     , "packages/data_contract_transitions"]
 
+[workspace.package]
+version = "1.0.4"
+
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[package]
-name = "pshenmic-dpp"
-version = "1.0.4"
-edition = "2024"
-rust-version = "1.85"
 
 [dependencies]
 wee_alloc = { version = "0.4.5", default-features = false }

--- a/packages/cbor_conversation/Cargo.toml
+++ b/packages/cbor_conversation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_document_search"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/data_contract/Cargo.toml
+++ b/packages/data_contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_data_contract"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/data_contract_transitions/Cargo.toml
+++ b/packages/data_contract_transitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_data_contract_transitions"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/packages/document/Cargo.toml
+++ b/packages/document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_document"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/documents_batch/Cargo.toml
+++ b/packages/documents_batch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_documents_batch"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/enums/Cargo.toml
+++ b/packages/enums/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_enums"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/identity/Cargo.toml
+++ b/packages/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_identity"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/identity_public_key/Cargo.toml
+++ b/packages/identity_public_key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_public_key"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/identity_transitions/Cargo.toml
+++ b/packages/identity_transitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_identity_transitions"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/mock_bls/Cargo.toml
+++ b/packages/mock_bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_mock_bls"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/private_key/Cargo.toml
+++ b/packages/private_key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_private_key"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/state_transition/Cargo.toml
+++ b/packages/state_transition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_state_transition"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic_dpp_utils"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
# Issue
At this moment every package had 0.1.0 version, but parrent packages had 1.0.4

# Things done 
- Updated all toml's by adding `[workspace.package]` to parrent toml and `version.workspace = true` for child packages