### PR TITLE
Type field for instances

### DIFF
--- a/packages/asset_lock_proof/src/chain/mod.rs
+++ b/packages/asset_lock_proof/src/chain/mod.rs
@@ -28,6 +28,11 @@ impl From<ChainAssetLockProof> for ChainAssetLockProofWASM {
 
 #[wasm_bindgen]
 impl ChainAssetLockProofWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "ChainAssetLockProofWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         core_chain_locked_height: u32,

--- a/packages/asset_lock_proof/src/instant/instant_lock.rs
+++ b/packages/asset_lock_proof/src/instant/instant_lock.rs
@@ -27,6 +27,11 @@ impl From<InstantLock> for InstantLockWASM {
 
 #[wasm_bindgen]
 impl InstantLockWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "InstantLockWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         version: u8,

--- a/packages/asset_lock_proof/src/instant/mod.rs
+++ b/packages/asset_lock_proof/src/instant/mod.rs
@@ -36,6 +36,11 @@ impl From<InstantAssetLockProof> for InstantAssetLockProofWASM {
 
 #[wasm_bindgen]
 impl InstantAssetLockProofWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "InstantAssetLockProofWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         instant_lock: Vec<u8>,

--- a/packages/asset_lock_proof/src/lib.rs
+++ b/packages/asset_lock_proof/src/lib.rs
@@ -63,6 +63,11 @@ impl From<AssetLockProof> for InstantAssetLockProofWASM {
 
 #[wasm_bindgen]
 impl AssetLockProofWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "AssetLockProofWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(js_asset_lock_proof_type: JsValue) -> Result<AssetLockProofWASM, JsValue> {
         let asset_lock_proof_type = AssetLockProofTypeWASM::try_from(js_asset_lock_proof_type)?;

--- a/packages/asset_lock_proof/src/outpoint/mod.rs
+++ b/packages/asset_lock_proof/src/outpoint/mod.rs
@@ -30,6 +30,11 @@ impl TryFrom<JsValue> for OutPointWASM {
 
 #[wasm_bindgen]
 impl OutPointWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "OutPointWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(txid_hex: String, vout: u32) -> Result<OutPointWASM, JsValue> {
         let out_point = Txid::from_hex(&txid_hex).map_err(|err| JsValue::from(err.to_string()))?;

--- a/packages/asset_lock_proof/src/tx_out/mod.rs
+++ b/packages/asset_lock_proof/src/tx_out/mod.rs
@@ -21,6 +21,11 @@ impl From<TxOutWASM> for TxOut {
 
 #[wasm_bindgen]
 impl TxOutWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "TxOutWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(value: u64, script_pubkey: JsValue) -> Result<TxOutWASM, JsValue> {
         let tx_out: Result<TxOut, JsValue> = match script_pubkey.is_array() {

--- a/packages/core_script/src/lib.rs
+++ b/packages/core_script/src/lib.rs
@@ -21,6 +21,11 @@ impl From<CoreScript> for CoreScriptWASM {
 
 #[wasm_bindgen]
 impl CoreScriptWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "CoreScriptWASM".to_string()
+    }
+
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(bytes: Vec<u8>) -> Self {
         CoreScriptWASM(CoreScript::from_bytes(bytes))

--- a/packages/data_contract/src/lib.rs
+++ b/packages/data_contract/src/lib.rs
@@ -40,6 +40,11 @@ impl From<DataContractWASM> for DataContract {
 
 #[wasm_bindgen]
 impl DataContractWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DataContractWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn from_js_values(
         js_owner_id: &JsValue,

--- a/packages/data_contract_transitions/src/create/mod.rs
+++ b/packages/data_contract_transitions/src/create/mod.rs
@@ -23,6 +23,11 @@ pub struct DataContractCreateTransitionWASM(DataContractCreateTransition);
 
 #[wasm_bindgen]
 impl DataContractCreateTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DataContractCreateTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         data_contract: &DataContractWASM,

--- a/packages/data_contract_transitions/src/update/mod.rs
+++ b/packages/data_contract_transitions/src/update/mod.rs
@@ -18,6 +18,11 @@ pub struct DataContractUpdateTransitionWASM(DataContractUpdateTransition);
 
 #[wasm_bindgen]
 impl DataContractUpdateTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DataContractUpdateTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         data_contract: &DataContractWASM,

--- a/packages/document/src/methods/mod.rs
+++ b/packages/document/src/methods/mod.rs
@@ -20,6 +20,11 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 #[wasm_bindgen]
 impl DocumentWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DocumentWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         js_raw_document: JsValue,

--- a/packages/documents_batch/src/document_base_transition/mod.rs
+++ b/packages/documents_batch/src/document_base_transition/mod.rs
@@ -24,6 +24,11 @@ impl From<DocumentBaseTransitionWASM> for DocumentBaseTransition {
 
 #[wasm_bindgen]
 impl DocumentBaseTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DocumentBaseTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         js_document_id: &JsValue,

--- a/packages/documents_batch/src/document_transition/mod.rs
+++ b/packages/documents_batch/src/document_transition/mod.rs
@@ -32,6 +32,11 @@ impl From<DocumentTransitionWASM> for DocumentTransition {
 
 #[wasm_bindgen]
 impl DocumentTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DocumentTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(getter = "actionType")]
     pub fn get_action_type(&self) -> String {
         BatchTypeWASM::from(self.0.action_type()).into()

--- a/packages/documents_batch/src/lib.rs
+++ b/packages/documents_batch/src/lib.rs
@@ -41,6 +41,11 @@ impl From<DocumentsBatchWASM> for DocumentsBatchTransition {
 
 #[wasm_bindgen]
 impl DocumentsBatchWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DocumentsBatchWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         document_transitions: &js_sys::Array,

--- a/packages/documents_batch/src/prefunded_voting_balance/mod.rs
+++ b/packages/documents_batch/src/prefunded_voting_balance/mod.rs
@@ -25,6 +25,11 @@ impl From<PrefundedVotingBalanceWASM> for (String, Credits) {
 
 #[wasm_bindgen]
 impl PrefundedVotingBalanceWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "PrefundedVotingBalanceWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(index_name: String, credits: Credits) -> PrefundedVotingBalanceWASM {
         PrefundedVotingBalanceWASM {

--- a/packages/documents_batch/src/transitions/create/mod.rs
+++ b/packages/documents_batch/src/transitions/create/mod.rs
@@ -30,6 +30,11 @@ impl From<DocumentCreateTransition> for DocumentCreateTransitionWASM {
 
 #[wasm_bindgen]
 impl DocumentCreateTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DocumentCreateTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         document: &DocumentWASM,

--- a/packages/documents_batch/src/transitions/delete/mod.rs
+++ b/packages/documents_batch/src/transitions/delete/mod.rs
@@ -26,6 +26,11 @@ impl From<DocumentDeleteTransitionWASM> for DocumentDeleteTransition {
 
 #[wasm_bindgen]
 impl DocumentDeleteTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DocumentDeleteTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         document: &DocumentWASM,

--- a/packages/documents_batch/src/transitions/purchase/mod.rs
+++ b/packages/documents_batch/src/transitions/purchase/mod.rs
@@ -26,6 +26,11 @@ impl From<DocumentPurchaseTransition> for DocumentPurchaseTransitionWASM {
 
 #[wasm_bindgen]
 impl DocumentPurchaseTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DocumentPurchaseTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         document: &DocumentWASM,

--- a/packages/documents_batch/src/transitions/replace/mod.rs
+++ b/packages/documents_batch/src/transitions/replace/mod.rs
@@ -28,6 +28,11 @@ impl From<DocumentReplaceTransitionWASM> for DocumentReplaceTransition {
 
 #[wasm_bindgen]
 impl DocumentReplaceTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DocumentReplaceTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         document: &DocumentWASM,

--- a/packages/documents_batch/src/transitions/transfer/mod.rs
+++ b/packages/documents_batch/src/transitions/transfer/mod.rs
@@ -26,6 +26,11 @@ impl From<DocumentTransferTransitionWASM> for DocumentTransferTransition {
 
 #[wasm_bindgen]
 impl DocumentTransferTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DocumentTransferTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         document: &DocumentWASM,

--- a/packages/documents_batch/src/transitions/update_price/mod.rs
+++ b/packages/documents_batch/src/transitions/update_price/mod.rs
@@ -20,6 +20,11 @@ impl From<DocumentUpdatePriceTransition> for DocumentUpdatePriceTransitionWASM {
 
 #[wasm_bindgen]
 impl DocumentUpdatePriceTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "DocumentUpdatePriceTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         document: &DocumentWASM,

--- a/packages/identity/src/lib.rs
+++ b/packages/identity/src/lib.rs
@@ -15,6 +15,11 @@ pub struct IdentityWASM(Identity);
 
 #[wasm_bindgen]
 impl IdentityWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(js_identifier: &JsValue) -> Result<IdentityWASM, JsValue> {
         let identifier: IdentifierWASM = js_identifier.try_into()?;

--- a/packages/identity_public_key/src/lib.rs
+++ b/packages/identity_public_key/src/lib.rs
@@ -35,6 +35,11 @@ impl From<IdentityPublicKeyWASM> for IdentityPublicKey {
 
 #[wasm_bindgen]
 impl IdentityPublicKeyWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityPublicKeyWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         id: u32,

--- a/packages/identity_transitions/src/create_transition/mod.rs
+++ b/packages/identity_transitions/src/create_transition/mod.rs
@@ -34,6 +34,11 @@ impl From<IdentityCreateTransitionWASM> for IdentityCreateTransition {
 
 #[wasm_bindgen]
 impl IdentityCreateTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityCreateTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         js_public_keys: &js_sys::Array,

--- a/packages/identity_transitions/src/credit_withdrawal_transition/mod.rs
+++ b/packages/identity_transitions/src/credit_withdrawal_transition/mod.rs
@@ -22,6 +22,11 @@ pub struct IdentityCreditWithdrawalTransitionWASM(IdentityCreditWithdrawalTransi
 
 #[wasm_bindgen]
 impl IdentityCreditWithdrawalTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityCreditWithdrawalTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         js_identity_id: JsValue,

--- a/packages/identity_transitions/src/identity_credit_transfer_transition/mod.rs
+++ b/packages/identity_transitions/src/identity_credit_transfer_transition/mod.rs
@@ -17,6 +17,11 @@ pub struct IdentityCreditTransferWASM(IdentityCreditTransferTransition);
 
 #[wasm_bindgen]
 impl IdentityCreditTransferWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityCreditTransferWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         amount: u64,

--- a/packages/identity_transitions/src/public_key_in_creation/mod.rs
+++ b/packages/identity_transitions/src/public_key_in_creation/mod.rs
@@ -63,6 +63,11 @@ impl From<IdentityPublicKeyInCreationWASM> for IdentityPublicKey {
 
 #[wasm_bindgen]
 impl IdentityPublicKeyInCreationWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityPublicKeyInCreationWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         id: u32,

--- a/packages/identity_transitions/src/top_up_transition/mod.rs
+++ b/packages/identity_transitions/src/top_up_transition/mod.rs
@@ -19,6 +19,11 @@ pub struct IdentityTopUpTransitionWASM(IdentityTopUpTransition);
 
 #[wasm_bindgen]
 impl IdentityTopUpTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityTopUpTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         asset_lock_proof: &AssetLockProofWASM,

--- a/packages/identity_transitions/src/update_transition/mod.rs
+++ b/packages/identity_transitions/src/update_transition/mod.rs
@@ -22,6 +22,11 @@ pub struct IdentityUpdateTransitionWASM(IdentityUpdateTransition);
 
 #[wasm_bindgen]
 impl IdentityUpdateTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityUpdateTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         js_identity_id: &JsValue,

--- a/packages/private_key/src/lib.rs
+++ b/packages/private_key/src/lib.rs
@@ -11,6 +11,11 @@ pub struct PrivateKeyWASM(PrivateKey);
 
 #[wasm_bindgen]
 impl PrivateKeyWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "PrivateKeyWASM".to_string()
+    }
+
     #[wasm_bindgen(js_name = "fromWIF")]
     pub fn from_wif(wif: &str) -> Result<Self, JsValue> {
         let pk = PrivateKey::from_wif(wif).map_err(|err| JsValue::from_str(&*err.to_string()));

--- a/packages/state_transition/src/lib.rs
+++ b/packages/state_transition/src/lib.rs
@@ -34,6 +34,11 @@ impl From<StateTransitionWASM> for StateTransition {
 
 #[wasm_bindgen]
 impl StateTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "StateTransitionWASM".to_string()
+    }
+
     #[wasm_bindgen(js_name = "sign")]
     pub fn sign(
         &mut self,

--- a/packages/utils/src/lib.rs
+++ b/packages/utils/src/lib.rs
@@ -221,11 +221,13 @@ pub fn get_bool_from_options(
     }
 }
 
-pub fn get_class_name(value: &JsValue) -> String {
-    js_sys::Object::get_prototype_of(value)
-        .constructor()
-        .name()
-        .into()
+pub fn get_class_type(value: &JsValue) -> Result<String, JsValue> {
+    let class_type = js_sys::Reflect::get(&value, &JsValue::from_str("__type"));
+
+    match class_type {
+        Ok(class_type) => Ok(class_type.as_string().unwrap_or("".to_string())),
+        Err(_) => Err(JsValue::from_str(&"")),
+    }
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
# Issue
If we obfuscate js code, we get the minimized class names and that can broke some methods. 

# Things done
- Implemented new getter for all structs, which named `__type`
- Updated identifier deserialization from js to wasm