### PR TITLE
CI pre-release detection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,13 @@ jobs:
           yarn tests
 
       - name: Publish package to NPM
-        run: yarn publish
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *"-"* ]]; then
+            TAG=$(echo "$VERSION" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z0-9]+).*/\1/')
+            yarn publish --tag "$TAG" --non-interactive
+          else
+            yarn publish --tag latest --non-interactive
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "tests": "mocha ./tests/*.spec.js",
     "lint": "cargo fmt"
   },
+  "files": [
+    "dist/wasm",
+    "tests/"
+  ],
   "author": "owl352",
   "license": "ISC",
   "description": "",


### PR DESCRIPTION
# Issue
We need to split releases and pre-releases for NPM

# Things done
- Updated CI to detect custom tag and push with this tag to npm
- Optimized package.json for npm