### PR TITLE
Document deserialization bug fix for data contract id

### DIFF
--- a/packages/document/src/methods/mod.rs
+++ b/packages/document/src/methods/mod.rs
@@ -344,6 +344,7 @@ impl DocumentWASM {
         let mut js_document = DocumentWASM::from(rs_document);
 
         js_document.set_document_type_name(type_name.clone().as_str());
+        js_document.set_data_contract_id(&data_contract.get_id());
 
         Ok(js_document)
     }
@@ -434,5 +435,9 @@ impl DocumentWASM {
 
     pub fn rs_get_properties(&self) -> BTreeMap<String, Value> {
         self.clone().properties
+    }
+
+    fn set_data_contract_id(&mut self, data_contract_id: &IdentifierWASM) {
+        self.data_contract_id = data_contract_id.clone();
     }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,7 @@ OUTPUT_FILE="${PWD}/wasm/pshenmic_dpp_bg.wasm"
 RUSTFLAGS="-C target-feature=+crt-static -C embed-bitcode=no -C metadata=reduced -C link-dead-code=no -C panic=abort"
 
 BUILD_COMMAND="cargo build --config net.git-fetch-with-cli=true --target=${TARGET} ${PROFILE_ARG}"
-STRIP_COMMAND=" wasm-snip ${PWD}/target/${TARGET}/${PROFILE}/pshenmic_dpp.wasm -o ${PWD}/target/${TARGET}/${PROFILE}/pshenmic_dpp.wasm --snip-rust-fmt-code --snip-rust-panicking-code"
+STRIP_COMMAND="wasm-snip ${PWD}/target/${TARGET}/${PROFILE}/pshenmic_dpp.wasm -o ${PWD}/target/${TARGET}/${PROFILE}/pshenmic_dpp.wasm --snip-rust-fmt-code --snip-rust-panicking-code"
 BINDGEN_COMMAND="wasm-bindgen --typescript --out-dir=${OUTPUT_DIR} --target=web --omit-default-module-path ${PWD}/target/${TARGET}/${PROFILE}/pshenmic_dpp.wasm"
 
 if ! [[ -d ${OUTPUT_DIR} ]]; then

--- a/tests/Document.spec.js
+++ b/tests/Document.spec.js
@@ -39,6 +39,7 @@ describe('Document', function () {
 
       const bytes = documentInstance.bytes(dataContract, wasm.PlatformVersionWASM.PLATFORM_V1)
 
+      assert.equal(documentInstance.getDataContractId().base58(), dataContract.getId().base58())
       assert.deepEqual(bytes, fromHexString(documentBytes))
       assert.notEqual(dataContract.__wbg_ptr, 0)
     })


### PR DESCRIPTION
# Issue
At this moment we have error with id for data contract in document after deserialization from bytes/hex/base

# Things done
- added new private methid for set data contract id
- updated test for deserialization