### PR TITLE
getOutPoint and getInstantLockBytes for locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.0.7-rc.9"
+version = "1.0.7-rc.10"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.0.7-rc.9"
+version = "1.0.7-rc.10"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.0.7-rc.9",
+  "version": "1.0.7-rc.10",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "repository": {

--- a/packages/asset_lock_proof/src/instant/mod.rs
+++ b/packages/asset_lock_proof/src/instant/mod.rs
@@ -123,4 +123,10 @@ impl InstantAssetLockProofWASM {
         let transaction = self.0.transaction();
         serialize(transaction)
     }
+
+    #[wasm_bindgen(js_name=getInstantLockBytes)]
+    pub fn get_instant_lock_bytes(&self) -> Vec<u8> {
+        let instant_lock = self.0.instant_lock();
+        serialize(instant_lock)
+    }
 }

--- a/packages/asset_lock_proof/src/lib.rs
+++ b/packages/asset_lock_proof/src/lib.rs
@@ -131,7 +131,7 @@ impl AssetLockProofWASM {
 
     #[wasm_bindgen(js_name = "getOutPoint")]
     pub fn get_out_point(&self) -> Option<OutPointWASM> {
-        match self.0.out_point() { 
+        match self.0.out_point() {
             Some(out_point) => Some(OutPointWASM::from(out_point)),
             None => None,
         }

--- a/packages/asset_lock_proof/src/lib.rs
+++ b/packages/asset_lock_proof/src/lib.rs
@@ -129,6 +129,14 @@ impl AssetLockProofWASM {
         self.clone().0.into()
     }
 
+    #[wasm_bindgen(js_name = "getOutPoint")]
+    pub fn get_out_point(&self) -> Option<OutPointWASM> {
+        match self.0.out_point() { 
+            Some(out_point) => Some(OutPointWASM::from(out_point)),
+            None => None,
+        }
+    }
+
     #[wasm_bindgen(js_name = "toObject")]
     pub fn to_object(&self) -> Result<JsValue, JsValue> {
         let json_value = self.0.to_raw_object().with_js_error()?;


### PR DESCRIPTION
# Issue
we need to implement `getInstantLockBytes` and `getOutPoint` for asset lock
# Things done
- new methods
- bump