### PR TITLE
Public key in creation contract bounds and hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.0.7-rc.10"
+version = "1.0.7-rc.11"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.0.7-rc.10"
+version = "1.0.7-rc.11"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.0.7-rc.10",
+  "version": "1.0.7-rc.11",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "repository": {

--- a/packages/identity_transitions/src/contract_bounds/mod.rs
+++ b/packages/identity_transitions/src/contract_bounds/mod.rs
@@ -1,0 +1,102 @@
+use dpp::identity::contract_bounds::ContractBounds;
+use pshenmic_dpp_identifier::IdentifierWASM;
+use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(js_name = "ContractBoundWASM")]
+#[derive(Clone)]
+pub struct ContractBoundsWASM(ContractBounds);
+
+impl From<ContractBounds> for ContractBoundsWASM {
+    fn from(bounds: ContractBounds) -> Self {
+        ContractBoundsWASM(bounds)
+    }
+}
+
+impl From<ContractBoundsWASM> for ContractBounds {
+    fn from(bounds: ContractBoundsWASM) -> Self {
+        bounds.0
+    }
+}
+
+#[wasm_bindgen]
+impl ContractBoundsWASM {
+    #[wasm_bindgen(js_name = "SingleContract")]
+    pub fn single_contract(js_contract_id: &JsValue) -> Result<ContractBoundsWASM, JsValue> {
+        let contract_id = IdentifierWASM::try_from(js_contract_id)?;
+
+        Ok(ContractBoundsWASM(ContractBounds::SingleContract {
+            id: contract_id.into(),
+        }))
+    }
+
+    #[wasm_bindgen(js_name = "SingleContractDocumentType")]
+    pub fn single_contract_document_type_name(
+        js_contract_id: &JsValue,
+        document_type_name: String,
+    ) -> Result<ContractBoundsWASM, JsValue> {
+        let contract_id = IdentifierWASM::try_from(js_contract_id)?;
+
+        Ok(ContractBoundsWASM(
+            ContractBounds::SingleContractDocumentType {
+                id: contract_id.into(),
+                document_type_name,
+            },
+        ))
+    }
+
+    #[wasm_bindgen(getter = "identifier")]
+    pub fn id(&self) -> IdentifierWASM {
+        self.0.identifier().clone().into()
+    }
+
+    #[wasm_bindgen(getter = "documentTypeName")]
+    pub fn document_type_name(&self) -> Option<String> {
+        match self.0.document_type() {
+            Some(name) => Some(name.clone()),
+            None => None,
+        }
+    }
+
+    #[wasm_bindgen(getter = "contractBoundsType")]
+    pub fn contract_bounds_type(&self) -> String {
+        self.0.contract_bounds_type_string().clone().into()
+    }
+
+    #[wasm_bindgen(getter = "contractBoundsTypeNumber")]
+    pub fn contract_bounds_type_number(&self) -> u8 {
+        self.0.contract_bounds_type()
+    }
+
+    #[wasm_bindgen(setter = "identifier")]
+    pub fn set_id(&mut self, js_contract_id: &JsValue) -> Result<(), JsValue> {
+        let contract_id = IdentifierWASM::try_from(js_contract_id)?;
+
+        self.0 = match self.clone().0 {
+            ContractBounds::SingleContract { .. } => ContractBounds::SingleContract {
+                id: contract_id.into(),
+            },
+            ContractBounds::SingleContractDocumentType {
+                document_type_name, ..
+            } => ContractBounds::SingleContractDocumentType {
+                id: contract_id.into(),
+                document_type_name,
+            },
+        };
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "documentTypeName")]
+    pub fn set_document_type_name(&mut self, document_type_name: String) {
+        self.0 = match self.clone().0 {
+            ContractBounds::SingleContract { .. } => self.clone().0,
+            ContractBounds::SingleContractDocumentType { id, .. } => {
+                ContractBounds::SingleContractDocumentType {
+                    id,
+                    document_type_name,
+                }
+            }
+        }
+    }
+}

--- a/packages/identity_transitions/src/lib.rs
+++ b/packages/identity_transitions/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod contract_bounds;
 pub mod create_transition;
 pub mod credit_withdrawal_transition;
 pub mod identity_credit_transfer_transition;


### PR DESCRIPTION
# Issue
We need to implement in `PublicKeyInCreationWASM` getters for contract bounds and hash

# Things done
- Implemented `ContractBoundsWASM`
- Implemented getters
- Bump