### PR TITLE
Fix links in `fromStateTransition` for identity transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.0.7-rc.12"
+version = "1.0.7-rc.13"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.0.7-rc.12"
+version = "1.0.7-rc.13"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.0.7-rc.12",
+  "version": "1.0.7-rc.13",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "repository": {

--- a/packages/identity_transitions/src/credit_withdrawal_transition/mod.rs
+++ b/packages/identity_transitions/src/credit_withdrawal_transition/mod.rs
@@ -235,9 +235,9 @@ impl IdentityCreditWithdrawalTransitionWASM {
 
     #[wasm_bindgen(js_name = "fromStateTransition")]
     pub fn from_state_transition(
-        st: StateTransitionWASM,
+        st: &StateTransitionWASM,
     ) -> Result<IdentityCreditWithdrawalTransitionWASM, JsValue> {
-        let rs_st: StateTransition = st.into();
+        let rs_st: StateTransition = st.clone().into();
 
         match rs_st {
             StateTransition::IdentityCreditWithdrawal(st) => {

--- a/packages/identity_transitions/src/identity_credit_transfer_transition/mod.rs
+++ b/packages/identity_transitions/src/identity_credit_transfer_transition/mod.rs
@@ -184,9 +184,9 @@ impl IdentityCreditTransferWASM {
 
     #[wasm_bindgen(js_name = "fromStateTransition")]
     pub fn from_state_transition(
-        st: StateTransitionWASM,
+        st: &StateTransitionWASM,
     ) -> Result<IdentityCreditTransferWASM, JsValue> {
-        let rs_st: StateTransition = st.into();
+        let rs_st: StateTransition = st.clone().into();
 
         match rs_st {
             StateTransition::IdentityCreditTransfer(st) => Ok(IdentityCreditTransferWASM(st)),

--- a/packages/identity_transitions/src/top_up_transition/mod.rs
+++ b/packages/identity_transitions/src/top_up_transition/mod.rs
@@ -164,9 +164,9 @@ impl IdentityTopUpTransitionWASM {
 
     #[wasm_bindgen(js_name = "fromStateTransition")]
     pub fn from_state_transition(
-        st: StateTransitionWASM,
+        st: &StateTransitionWASM,
     ) -> Result<IdentityTopUpTransitionWASM, JsValue> {
-        let rs_st: StateTransition = st.into();
+        let rs_st: StateTransition = st.clone().into();
 
         match rs_st {
             StateTransition::IdentityTopUp(st) => Ok(IdentityTopUpTransitionWASM(st)),

--- a/packages/identity_transitions/src/update_transition/mod.rs
+++ b/packages/identity_transitions/src/update_transition/mod.rs
@@ -238,9 +238,9 @@ impl IdentityUpdateTransitionWASM {
 
     #[wasm_bindgen(js_name = "fromStateTransition")]
     pub fn from_state_transition(
-        st: StateTransitionWASM,
+        st: &StateTransitionWASM,
     ) -> Result<IdentityUpdateTransitionWASM, JsValue> {
-        let rs_st: StateTransition = st.into();
+        let rs_st: StateTransition = st.clone().into();
 
         match rs_st {
             StateTransition::IdentityUpdate(st) => Ok(IdentityUpdateTransitionWASM(st)),


### PR DESCRIPTION
# Issue
We have error in `fromStateTransition` for identity transitions, and we destroy transition instance after passing as argument to this methods
# Things done
- bug fix
- bump