### PR TITLE
DataContract Update getIdentityNonce -> getIdentityContractNonce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.0.7-rc.16"
+version = "1.0.7-rc.17"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.0.7-rc.16"
+version = "1.0.7-rc.17"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.0.7-rc.16",
+  "version": "1.0.7-rc.17",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "repository": {

--- a/packages/data_contract_transitions/src/update/mod.rs
+++ b/packages/data_contract_transitions/src/update/mod.rs
@@ -132,7 +132,7 @@ impl DataContractUpdateTransitionWASM {
         Ok(())
     }
 
-    #[wasm_bindgen(js_name = "getIdentityNonce")]
+    #[wasm_bindgen(js_name = "getIdentityContractNonce")]
     pub fn get_identity_nonce(&self) -> IdentityNonce {
         self.0.identity_contract_nonce()
     }


### PR DESCRIPTION
# Issue
We need to fix naming for `getIdentityNonce` method in data contract update
# Things done
- Fixed naming
- Bump