### PR TITLE
Fixes for token configuration in DataContract

### DIFF
--- a/packages/data_contract/src/lib.rs
+++ b/packages/data_contract/src/lib.rs
@@ -96,7 +96,10 @@ impl DataContractWASM {
         let schema: Value = serde_wasm_bindgen::from_value(js_schema)?;
 
         let tokens: BTreeMap<TokenContractPosition, TokenConfiguration> =
-            tokens_configuration_from_js_value(js_tokens)?;
+            match js_tokens.is_undefined() {
+                true => BTreeMap::new(),
+                false => tokens_configuration_from_js_value(js_tokens)?,
+            };
 
         let platform_version: PlatformVersion = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default().into(),

--- a/packages/document/src/methods/mod.rs
+++ b/packages/document/src/methods/mod.rs
@@ -34,7 +34,7 @@ impl DocumentWASM {
         js_revision: u64,
         js_data_contract_id: &JsValue,
         js_owner_id: &JsValue,
-        js_document_id: JsValue,
+        js_document_id: &JsValue,
     ) -> Result<DocumentWASM, JsValue> {
         let data_contract_id = IdentifierWASM::try_from(js_data_contract_id)?;
         let owner_id = IdentifierWASM::try_from(js_owner_id)?;

--- a/tests/Document.spec.js
+++ b/tests/Document.spec.js
@@ -179,6 +179,23 @@ describe('Document', function () {
     it('should allow to set create at core Block Height', () => {
       const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
 
+      ///
+      ///
+      ///
+      const st
+
+      const batch = BatchTransitionWASM.fromST(st)
+
+      const [transition] = batch.transitions
+
+      const documentTransition = transition.toTransition()
+
+      const dataContractId = documentTransition.createTransition.base.dataContractId
+      const dataContractId = documentTransition.getCreateTransition().getBase().getDataContractId()
+      ///
+      ///
+      ///
+
       const createdAtHeight = 91721
 
       documentInstance.createdAtCoreBlockHeight = createdAtHeight

--- a/tests/Document.spec.js
+++ b/tests/Document.spec.js
@@ -179,23 +179,6 @@ describe('Document', function () {
     it('should allow to set create at core Block Height', () => {
       const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
 
-      ///
-      ///
-      ///
-      const st
-
-      const batch = BatchTransitionWASM.fromST(st)
-
-      const [transition] = batch.transitions
-
-      const documentTransition = transition.toTransition()
-
-      const dataContractId = documentTransition.createTransition.base.dataContractId
-      const dataContractId = documentTransition.getCreateTransition().getBase().getDataContractId()
-      ///
-      ///
-      ///
-
       const createdAtHeight = 91721
 
       documentInstance.createdAtCoreBlockHeight = createdAtHeight


### PR DESCRIPTION
# Issue
At this moment we have bug with token configuration which required not undefined object
# Things done
- added match for undefined in token configuration
- fixed id link in documents