### PR TITLE
Fix class names in `to_wasm`

### DIFF
--- a/packages/utils/src/lib.rs
+++ b/packages/utils/src/lib.rs
@@ -177,9 +177,7 @@ pub fn generic_of_js_val<T: RefFromWasmAbi<Abi = u32>>(
         .into());
     }
 
-    let ctor_name = js_sys::Object::get_prototype_of(js_value)
-        .constructor()
-        .name();
+    let ctor_name = get_class_type(js_value)?;
 
     if ctor_name == class_name {
         let ptr = js_sys::Reflect::get(js_value, &JsValue::from_str("__wbg_ptr"))?;


### PR DESCRIPTION
# Issue
`to_wasm` method at this moment use name from constructor, but this not working in bundles, where classes can be renamed

# Things done
- use our `get_class_name` instead constructor