### PR TITLE
Custom class asseteration patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "type": "module",

--- a/packages/token_configuration/src/distribution_rules.rs
+++ b/packages/token_configuration/src/distribution_rules.rs
@@ -32,6 +32,11 @@ impl From<TokenDistributionRules> for TokenDistributionRulesWASM {
 
 #[wasm_bindgen]
 impl TokenDistributionRulesWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "TokenDistributionRulesWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         js_perpetual_distribution: &JsValue,

--- a/packages/token_configuration/src/marketplace_rules.rs
+++ b/packages/token_configuration/src/marketplace_rules.rs
@@ -25,6 +25,11 @@ impl From<TokenMarketplaceRulesWASM> for TokenMarketplaceRules {
 
 #[wasm_bindgen]
 impl TokenMarketplaceRulesWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "TokenMarketplaceRulesWASM".to_string()
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new(
         trade_mode: &TokenTradeModeWASM,

--- a/packages/token_configuration/src/reward_distribution_type.rs
+++ b/packages/token_configuration/src/reward_distribution_type.rs
@@ -109,6 +109,11 @@ pub struct EpochBasedDistributionWASM {
 
 #[wasm_bindgen]
 impl BlockBasedDistributionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "BlockBasedDistributionWASM".to_string()
+    }
+
     #[wasm_bindgen(getter = "function")]
     pub fn get_function(&self) -> DistributionFunctionWASM {
         self.function.clone()
@@ -122,6 +127,11 @@ impl BlockBasedDistributionWASM {
 
 #[wasm_bindgen]
 impl TimeBasedDistributionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "TimeBasedDistributionWASM".to_string()
+    }
+
     #[wasm_bindgen(getter = "function")]
     pub fn get_function(&self) -> DistributionFunctionWASM {
         self.function.clone()
@@ -135,6 +145,11 @@ impl TimeBasedDistributionWASM {
 
 #[wasm_bindgen]
 impl EpochBasedDistributionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "EpochBasedDistributionWASM".to_string()
+    }
+
     #[wasm_bindgen(getter = "function")]
     pub fn get_function(&self) -> DistributionFunctionWASM {
         self.function.clone()

--- a/scripts/build-js.sh
+++ b/scripts/build-js.sh
@@ -51,6 +51,15 @@ cp -a $WASM_TS_INDEX_CODE_PATH $DIST_WASM_DIR
 cp $WASM_TS_BG_CODE_PATH $DIST_WASM_TS_BG
 cp $WASM_TS_CODE_PATH $DIST_WASM_TS
 
+echo "Patching assert to custom type checker"
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "SYSTEM: Darwin"
+  sed -i '' 's#if (!(instance instanceof klass)) {#if (!(instance?.__type === klass.name)) {#g' $DIST_WASM_JS
+else
+  echo "SYSTEM: GNU"
+  sed -i 's#if (!(instance instanceof klass)) {#if (!(instance?.__type === klass.name)) {#g' $DIST_WASM_JS
+fi
+
 echo "Cleaning wasm build"
 rm -rf $WASM_DIR
 


### PR DESCRIPTION
# Issue
We need to implement custom asseteration for classes because default assert not working with bundlers like vite

# Things done
- Implemented sh patcher, which changiing logic from assert via `instanceOf` to  assert via our `__type`
- Bump