### PR TITLE
Method for token identifier calculation

### DIFF
--- a/packages/identifier/src/lib.rs
+++ b/packages/identifier/src/lib.rs
@@ -19,6 +19,12 @@ impl From<Identifier> for IdentifierWASM {
     }
 }
 
+impl From<[u8; 32]> for IdentifierWASM {
+    fn from(identifier: [u8;32]) -> Self {
+        IdentifierWASM(Identifier::new(identifier))
+    }
+}
+
 impl From<&IdentifierWASM> for Identifier {
     fn from(identifier: &IdentifierWASM) -> Self {
         identifier.clone().into()
@@ -121,5 +127,11 @@ impl IdentifierWASM {
             Identifier::from_vec(bytes).map_err(|err| JsValue::from(err.to_string()))?;
 
         Ok(IdentifierWASM(identifier))
+    }
+}
+
+impl IdentifierWASM {
+    pub fn to_slice(&self) -> [u8; 32] {
+        self.0.as_bytes().clone()
     }
 }

--- a/packages/identifier/src/lib.rs
+++ b/packages/identifier/src/lib.rs
@@ -20,7 +20,7 @@ impl From<Identifier> for IdentifierWASM {
 }
 
 impl From<[u8; 32]> for IdentifierWASM {
-    fn from(identifier: [u8;32]) -> Self {
+    fn from(identifier: [u8; 32]) -> Self {
         IdentifierWASM(Identifier::new(identifier))
     }
 }

--- a/packages/token_configuration/src/lib.rs
+++ b/packages/token_configuration/src/lib.rs
@@ -11,9 +11,9 @@ use dpp::data_contract::associated_token::token_configuration::accessors::v0::{
 use dpp::data_contract::associated_token::token_configuration::v0::TokenConfigurationV0;
 use dpp::data_contract::{GroupContractPosition, TokenConfiguration, TokenContractPosition};
 use dpp::tokens::calculate_token_id;
+use pshenmic_dpp_identifier::IdentifierWASM;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
-use pshenmic_dpp_identifier::IdentifierWASM;
 
 pub mod action_taker;
 pub mod authorized_action_takers;
@@ -316,11 +316,17 @@ impl TokenConfigurationWASM {
     pub fn set_description(&mut self, description: Option<String>) {
         self.0.set_description(description)
     }
-    
+
     #[wasm_bindgen(js_name = "calculateTokenId")]
-    pub fn calculate_token_id(js_contract_id: &JsValue, token_pos: TokenContractPosition) -> Result<IdentifierWASM, JsValue> {
+    pub fn calculate_token_id(
+        js_contract_id: &JsValue,
+        token_pos: TokenContractPosition,
+    ) -> Result<IdentifierWASM, JsValue> {
         let contract_id = IdentifierWASM::try_from(js_contract_id)?;
-        
-        Ok(IdentifierWASM::from(calculate_token_id(&contract_id.to_slice(), token_pos)))
+
+        Ok(IdentifierWASM::from(calculate_token_id(
+            &contract_id.to_slice(),
+            token_pos,
+        )))
     }
 }

--- a/packages/token_configuration/src/lib.rs
+++ b/packages/token_configuration/src/lib.rs
@@ -9,8 +9,11 @@ use dpp::data_contract::associated_token::token_configuration::accessors::v0::{
     TokenConfigurationV0Getters, TokenConfigurationV0Setters,
 };
 use dpp::data_contract::associated_token::token_configuration::v0::TokenConfigurationV0;
-use dpp::data_contract::{GroupContractPosition, TokenConfiguration};
+use dpp::data_contract::{GroupContractPosition, TokenConfiguration, TokenContractPosition};
+use dpp::tokens::calculate_token_id;
+use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
+use pshenmic_dpp_identifier::IdentifierWASM;
 
 pub mod action_taker;
 pub mod authorized_action_takers;
@@ -312,5 +315,12 @@ impl TokenConfigurationWASM {
     #[wasm_bindgen(setter = "description")]
     pub fn set_description(&mut self, description: Option<String>) {
         self.0.set_description(description)
+    }
+    
+    #[wasm_bindgen(js_name = "calculateTokenId")]
+    pub fn calculate_token_id(js_contract_id: &JsValue, token_pos: TokenContractPosition) -> Result<IdentifierWASM, JsValue> {
+        let contract_id = IdentifierWASM::try_from(js_contract_id)?;
+        
+        Ok(IdentifierWASM::from(calculate_token_id(&contract_id.to_slice(), token_pos)))
     }
 }


### PR DESCRIPTION
# Issue
At this moment we cannot get token id in pshenmic-dpp

# Things done
- Added token id calculation method to TokenConfiguration
- Added some rust-level convertations for `IdentifierWASM`