### PR TITLE
Fix token pricing serialization toJS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.0.18"
+version = "1.0.19"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "repository": {

--- a/packages/batch/src/token_pricing_schedule/mod.rs
+++ b/packages/batch/src/token_pricing_schedule/mod.rs
@@ -1,5 +1,4 @@
 use dpp::balances::credits::TokenAmount;
-use dpp::dashcore::hashes::serde::Serialize;
 use dpp::fee::Credits;
 use dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
 use pshenmic_dpp_utils::ToSerdeJSONExt;

--- a/packages/batch/src/token_pricing_schedule/mod.rs
+++ b/packages/batch/src/token_pricing_schedule/mod.rs
@@ -4,6 +4,7 @@ use dpp::fee::Credits;
 use dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
 use pshenmic_dpp_utils::ToSerdeJSONExt;
 use std::collections::BTreeMap;
+use js_sys::{Object, Reflect};
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -66,9 +67,13 @@ impl TokenPricingScheduleWASM {
                 Ok(JsValue::bigint_from_str(&credits.to_string()))
             }
             TokenPricingSchedule::SetPrices(prices) => {
-                let serializer = serde_wasm_bindgen::Serializer::json_compatible();
-
-                prices.serialize(&serializer).map_err(JsValue::from)
+                let price_object = Object::new();
+                
+                for (key, value) in prices.iter() {
+                    Reflect::set(&price_object, &JsValue::from(key.to_string()), &value.clone().into())?;
+                }
+                
+                Ok(price_object.into())
             }
         }
     }

--- a/packages/batch/src/token_pricing_schedule/mod.rs
+++ b/packages/batch/src/token_pricing_schedule/mod.rs
@@ -1,9 +1,9 @@
 use dpp::balances::credits::TokenAmount;
 use dpp::fee::Credits;
 use dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
+use js_sys::{Object, Reflect};
 use pshenmic_dpp_utils::ToSerdeJSONExt;
 use std::collections::BTreeMap;
-use js_sys::{Object, Reflect};
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -67,11 +67,15 @@ impl TokenPricingScheduleWASM {
             }
             TokenPricingSchedule::SetPrices(prices) => {
                 let price_object = Object::new();
-                
+
                 for (key, value) in prices.iter() {
-                    Reflect::set(&price_object, &JsValue::from(key.to_string()), &value.clone().into())?;
+                    Reflect::set(
+                        &price_object,
+                        &JsValue::from(key.to_string()),
+                        &value.clone().into(),
+                    )?;
                 }
-                
+
                 Ok(price_object.into())
             }
         }


### PR DESCRIPTION
# Issue
```
Error: Map key is not a string and cannot be an object key
```
# Things done
- Added Reflect to serialization instead wasm serde
- Bump