### PR TITLE
Asset lock proof serialization and deserialization in hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,8 +527,8 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "2.0.0"
-source = "git+https://github.com/dashpay/platform?tag=v2.0.0#bcbbad13029ee952c41fb185612e61fde2561f14"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?tag=v2.0.1#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1130,8 +1130,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization"
-version = "2.0.0"
-source = "git+https://github.com/dashpay/platform?tag=v2.0.0#bcbbad13029ee952c41fb185612e61fde2561f14"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?tag=v2.0.1#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "bincode",
  "platform-version",
@@ -1139,8 +1139,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "2.0.0"
-source = "git+https://github.com/dashpay/platform?tag=v2.0.0#bcbbad13029ee952c41fb185612e61fde2561f14"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?tag=v2.0.1#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1150,8 +1150,8 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "2.0.0"
-source = "git+https://github.com/dashpay/platform?tag=v2.0.0#bcbbad13029ee952c41fb185612e61fde2561f14"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?tag=v2.0.1#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "base64",
  "bincode",
@@ -1169,8 +1169,8 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "2.0.0"
-source = "git+https://github.com/dashpay/platform?tag=v2.0.0#bcbbad13029ee952c41fb185612e61fde2561f14"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?tag=v2.0.1#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "bincode",
  "grovedb-version",
@@ -1181,8 +1181,8 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "2.0.0"
-source = "git+https://github.com/dashpay/platform?tag=v2.0.0#bcbbad13029ee952c41fb185612e61fde2561f14"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?tag=v2.0.1#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1255,13 +1255,14 @@ name = "pshenmic_dpp_asset_lock_proof"
 version = "1.0.5"
 dependencies = [
  "dpp",
+ "hex",
  "js-sys",
  "pshenmic_dpp_enums",
  "pshenmic_dpp_utils",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1512,7 +1513,6 @@ dependencies = [
  "dpp",
  "js-sys",
  "serde",
- "serde-wasm-bindgen",
  "serde_json",
  "wasm-bindgen",
 ]
@@ -2045,16 +2045,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [workspace.dependencies]
-dpp = { git = "https://github.com/dashpay/platform", tag = "v2.0.0", default-features = false }
+dpp = { git = "https://github.com/dashpay/platform", tag = "v2.0.1", default-features = false }
 
 [workspace.package]
 version = "1.0.5"

--- a/packages/asset_lock_proof/Cargo.toml
+++ b/packages/asset_lock_proof/Cargo.toml
@@ -14,6 +14,7 @@ dpp = { workspace = true, features = [
 pshenmic_dpp_utils = {path = "../utils"}
 pshenmic_dpp_enums = {path = "../enums"}
 js-sys = "0.3.53"
-web-sys = {version = "0.3.77", features = ["console"]}
 serde-wasm-bindgen = { git = "https://github.com/QuantumExplorer/serde-wasm-bindgen", branch = "feat/not_human_readable" }
 serde = { version = "1.0.197", features = ["derive"] }
+hex = "0.4.3"
+serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/packages/asset_lock_proof/src/lib.rs
+++ b/packages/asset_lock_proof/src/lib.rs
@@ -102,20 +102,6 @@ impl AssetLockProofWASM {
         Ok(ChainAssetLockProofWASM::new(core_chain_locked_height, out_point)?.into())
     }
 
-    // #[wasm_bindgen(js_name = "fromRawObject")]
-    // pub fn from_raw_object(raw_asset_lock_proof: JsValue) -> Result<AssetLockProofWASM, JsValue> {
-    //     let lock_type = get_type_from_raw_asset_lock_proof(&raw_asset_lock_proof)?;
-    //
-    //     match lock_type {
-    //         AssetLockProofTypeWASM::Instant => {
-    //             Ok(InstantAssetLockProofWASM::from_raw_value(raw_asset_lock_proof)?.into())
-    //         }
-    //         AssetLockProofTypeWASM::Chain => {
-    //             Ok(ChainAssetLockProofWASM::from_raw_value(raw_asset_lock_proof)?.into())
-    //         }
-    //     }
-    // }
-
     #[wasm_bindgen(js_name = "getLockType")]
     pub fn get_lock_type(&self) -> String {
         match self.0 {

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -15,5 +15,4 @@ dpp = { workspace = true, features = [
 ] }
 js-sys = "0.3.53"
 serde_json = { version = "1.0", features = ["preserve_order"] }
-serde-wasm-bindgen = { git = "https://github.com/QuantumExplorer/serde-wasm-bindgen", branch = "feat/not_human_readable" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/packages/utils/src/lib.rs
+++ b/packages/utils/src/lib.rs
@@ -85,15 +85,6 @@ pub fn to_vec_of_platform_values(
         .collect()
 }
 
-pub fn into_vec_of<T>(iter: &[JsValue]) -> Vec<T>
-where
-    T: for<'de> serde::de::Deserialize<'de>,
-{
-    iter.iter()
-        .map(|v| serde_wasm_bindgen::from_value(v.clone()).expect("data malformed"))
-        .collect()
-}
-
 pub fn with_serde_to_json_value(data: JsValue) -> Result<JsonValue, JsValue> {
     let data = stringify(&data)?;
     let value: JsonValue = serde_json::from_str(&data)

--- a/tests/AssetLockProof.spec.cjs
+++ b/tests/AssetLockProof.spec.cjs
@@ -35,6 +35,17 @@ describe('AssetLockProof', function () {
 
       assert.equal(chainLockProof.constructor.name, 'AssetLockProofWASM')
     })
+
+    it('should allow to serialize and deserialize asset lock in hex', () => {
+      const instantLockProof = wasm.AssetLockProofWASM.createInstantAssetLockProof(instantLockBytes, transactionBytes, 0)
+
+      const newInstantLockProof = wasm.AssetLockProofWASM.fromHex(instantLockProof.hex())
+
+      assert.equal(instantLockProof.constructor.name, 'AssetLockProofWASM')
+      assert.equal(newInstantLockProof.constructor.name, 'AssetLockProofWASM')
+
+      assert.deepEqual(newInstantLockProof.toObject(), instantLockProof.toObject())
+    })
   })
 
   describe('getters', function () {


### PR DESCRIPTION
# Issue
We need to implement serialization to hex and deserialization from hex for asset lock proof, because some infrastructures requires hex encoded asset lock proof

# Things done
- Implemented `hex()`
- Implemented `fromHex()`
- Bumped platform to 2.0.1
- New test for serialization and deserialization in AssetLockProof