### PR TITLE
Fix error handling for document constructor

### DIFF
--- a/packages/consensus_error/src/lib.rs
+++ b/packages/consensus_error/src/lib.rs
@@ -1,22 +1,4 @@
-use dpp::consensus;
 use dpp::consensus::ConsensusError;
-use dpp::consensus::basic::data_contract::data_contract_max_depth_exceed_error::DataContractMaxDepthExceedError;
-use dpp::consensus::basic::data_contract::{
-    DocumentTypesAreMissingError, DuplicateIndexError, UnknownDocumentCreationRestrictionModeError,
-    UnknownSecurityLevelError, UnknownStorageKeyRequirementsError, UnknownTradeModeError,
-    UnknownTransferableTypeError,
-};
-use dpp::consensus::basic::decode::{DecodingError, SerializedObjectParsingError};
-use dpp::consensus::basic::document::InvalidDocumentTypeError;
-use dpp::consensus::basic::invalid_identifier_error::InvalidIdentifierError;
-use dpp::consensus::basic::json_schema_compilation_error::JsonSchemaCompilationError;
-use dpp::consensus::basic::value_error::ValueError;
-use dpp::consensus::basic::{
-    BasicError, IncompatibleProtocolVersionError, UnsupportedProtocolVersionError,
-    UnsupportedVersionError,
-};
-use dpp::data_contract::errors::{DataContractError, JsonSchemaError};
-use dpp::platform_value::string_encoding::Encoding;
 use dpp::serialization::PlatformDeserializable;
 use pshenmic_dpp_utils::WithJsError;
 use wasm_bindgen::JsValue;

--- a/packages/document/src/methods/mod.rs
+++ b/packages/document/src/methods/mod.rs
@@ -54,7 +54,7 @@ impl DocumentWASM {
 
         let entropy = entropy_generator::DefaultEntropyGenerator
             .generate()
-            .unwrap();
+            .map_err(|err| JsValue::from(err.to_string()))?;
 
         let document_id: IdentifierWASM = match js_document_id.is_undefined() {
             true => pshenmic_dpp_utils::generate_document_id_v0(


### PR DESCRIPTION
# Issue
At this moment if we get entropy error we get error `unreachable`
# Things done
- Added error map instead unwrap