### PR TITLE
Fix verify methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.0.23"
+version = "1.0.24"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.0.23"
+version = "1.0.24"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "repository": {

--- a/packages/enums/src/platform/mod.rs
+++ b/packages/enums/src/platform/mod.rs
@@ -16,15 +16,15 @@ use wasm_bindgen::prelude::wasm_bindgen;
 #[allow(non_camel_case_types)]
 pub enum PlatformVersionWASM {
     #[default]
-    PLATFORM_V1 = 0,
-    PLATFORM_V2 = 1,
-    PLATFORM_V3 = 2,
-    PLATFORM_V4 = 3,
-    PLATFORM_V5 = 4,
-    PLATFORM_V6 = 5,
-    PLATFORM_V7 = 6,
-    PLATFORM_V8 = 7,
-    PLATFORM_V9 = 8,
+    PLATFORM_V1 = 1,
+    PLATFORM_V2 = 2,
+    PLATFORM_V3 = 3,
+    PLATFORM_V4 = 4,
+    PLATFORM_V5 = 5,
+    PLATFORM_V6 = 6,
+    PLATFORM_V7 = 7,
+    PLATFORM_V8 = 8,
+    PLATFORM_V9 = 9,
 }
 
 impl TryFrom<JsValue> for PlatformVersionWASM {
@@ -52,15 +52,15 @@ impl TryFrom<JsValue> for PlatformVersionWASM {
             false => match value.as_f64() {
                 None => Err(JsValue::from("cannot read value from enum")),
                 Some(enum_val) => match enum_val as u8 {
-                    0 => Ok(PlatformVersionWASM::PLATFORM_V1),
-                    1 => Ok(PlatformVersionWASM::PLATFORM_V2),
-                    2 => Ok(PlatformVersionWASM::PLATFORM_V3),
-                    3 => Ok(PlatformVersionWASM::PLATFORM_V4),
-                    4 => Ok(PlatformVersionWASM::PLATFORM_V5),
-                    5 => Ok(PlatformVersionWASM::PLATFORM_V6),
-                    6 => Ok(PlatformVersionWASM::PLATFORM_V7),
-                    7 => Ok(PlatformVersionWASM::PLATFORM_V8),
-                    8 => Ok(PlatformVersionWASM::PLATFORM_V9),
+                    1 => Ok(PlatformVersionWASM::PLATFORM_V1),
+                    2 => Ok(PlatformVersionWASM::PLATFORM_V2),
+                    3 => Ok(PlatformVersionWASM::PLATFORM_V3),
+                    4 => Ok(PlatformVersionWASM::PLATFORM_V4),
+                    5 => Ok(PlatformVersionWASM::PLATFORM_V5),
+                    6 => Ok(PlatformVersionWASM::PLATFORM_V6),
+                    7 => Ok(PlatformVersionWASM::PLATFORM_V7),
+                    8 => Ok(PlatformVersionWASM::PLATFORM_V8),
+                    9 => Ok(PlatformVersionWASM::PLATFORM_V9),
                     _ => Err(JsValue::from(format!(
                         "unknown platform version value: {}",
                         enum_val

--- a/packages/verify/src/verify_contested/vote_state.rs
+++ b/packages/verify/src/verify_contested/vote_state.rs
@@ -1,5 +1,4 @@
 use crate::verify_contested::contested_document_vote_poll_query_execution_result::ContestedDocumentVotePollQueryExecutionResultWASM;
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use dpp::data_contract::DataContract;
 use dpp::platform_value::Value;
 use dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePoll;
@@ -34,10 +33,8 @@ impl VerifiedVoteStateWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "result")]

--- a/packages/verify/src/verify_contract/mod.rs
+++ b/packages/verify/src/verify_contract/mod.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::drive::Drive;
 use drive::verify::RootHash;
 use js_sys::Uint8Array;
@@ -27,10 +26,8 @@ impl VerifiedContractWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "dataContract")]
@@ -39,7 +36,7 @@ impl VerifiedContractWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyContract")]
+#[wasm_bindgen(js_name = "verifyContractProof")]
 pub fn verify_contract(
     proof: &Uint8Array,
     contract_known_keeps_history: Option<bool>,

--- a/packages/verify/src/verify_document/mod.rs
+++ b/packages/verify/src/verify_document/mod.rs
@@ -98,9 +98,9 @@ pub fn verify_document_proof(
         .iter()
         .map(|doc| {
             let mut doc_wasm = DocumentWASM::from(doc.clone());
-            
+
             doc_wasm.set_js_data_contract_id(&contract.get_id().clone().into())?;
-            
+
             Ok::<DocumentWASM, JsValue>(doc_wasm)
         })
         .collect::<Result<Vec<DocumentWASM>, JsValue>>()?;

--- a/packages/verify/src/verify_document/mod.rs
+++ b/packages/verify/src/verify_document/mod.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::query::WhereOperator::{
     Between, BetweenExcludeBounds, BetweenExcludeLeft, BetweenExcludeRight, Equal, GreaterThan,
     GreaterThanOrEquals, In, LessThan, LessThanOrEquals, StartsWith,
@@ -34,10 +33,8 @@ impl VerifiedDocumentsWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "documents")]
@@ -99,8 +96,14 @@ pub fn verify_document_proof(
 
     let wasm_documents = documents
         .iter()
-        .map(|doc| DocumentWASM::from(doc.clone()))
-        .collect();
+        .map(|doc| {
+            let mut doc_wasm = DocumentWASM::from(doc.clone());
+            
+            doc_wasm.set_js_data_contract_id(&contract.get_id().clone().into())?;
+            
+            Ok::<DocumentWASM, JsValue>(doc_wasm)
+        })
+        .collect::<Result<Vec<DocumentWASM>, JsValue>>()?;
 
     Ok(VerifiedDocumentsWASM {
         root_hash,

--- a/packages/verify/src/verify_identity/verify_identifier_by_non_unique_public_key_hash.rs
+++ b/packages/verify/src/verify_identity/verify_identifier_by_non_unique_public_key_hash.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::drive::Drive;
 use drive::verify::RootHash;
 use js_sys::Uint8Array;
@@ -26,10 +25,8 @@ impl VerifiedIdentifierByNonUniquePublicKeyHashWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "identifier")]
@@ -38,7 +35,7 @@ impl VerifiedIdentifierByNonUniquePublicKeyHashWASM {
     }
 }
 
-#[wasm_bindgen(js_name = verifyIdentifierByNonUniquePublicKeyHash)]
+#[wasm_bindgen(js_name = "verifyIdentifierByNonUniquePublicKeyHashProof")]
 pub fn verify_identifier_by_non_unique_public_key_hash(
     proof: &Uint8Array,
     is_proof_subset: bool,

--- a/packages/verify/src/verify_identity/verify_identity_balance.rs
+++ b/packages/verify/src/verify_identity/verify_identity_balance.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::drive::Drive;
 use drive::verify::RootHash;
 use js_sys::Uint8Array;
@@ -26,10 +25,8 @@ impl VerifiedIdentityBalanceWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "balance")]
@@ -38,7 +35,7 @@ impl VerifiedIdentityBalanceWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyIdentityBalance")]
+#[wasm_bindgen(js_name = "verifyIdentityBalanceProof")]
 pub fn verify_identity_balance(
     proof: &Uint8Array,
     js_identity_id: &JsValue,

--- a/packages/verify/src/verify_identity/verify_identity_by_identifier.rs
+++ b/packages/verify/src/verify_identity/verify_identity_by_identifier.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::drive::Drive;
 use drive::verify::RootHash;
 use js_sys::Uint8Array;
@@ -27,10 +26,8 @@ impl VerifiedIdentityByIdentifierWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "identity")]
@@ -39,7 +36,7 @@ impl VerifiedIdentityByIdentifierWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyIdentityByIdentifier")]
+#[wasm_bindgen(js_name = "verifyIdentityByIdentifierProof")]
 pub fn verify_identity_by_identifier(
     proof: &Uint8Array,
     js_identity_id: &JsValue,

--- a/packages/verify/src/verify_identity/verify_identity_by_unique_public_key_hash.rs
+++ b/packages/verify/src/verify_identity/verify_identity_by_unique_public_key_hash.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::drive::Drive;
 use drive::verify::RootHash;
 use js_sys::Uint8Array;
@@ -26,10 +25,8 @@ impl VerifiedIdentityByUniqueKeyHashWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "identity")]
@@ -38,7 +35,7 @@ impl VerifiedIdentityByUniqueKeyHashWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyIdentityByUniqueKeyHash")]
+#[wasm_bindgen(js_name = "verifyIdentityByUniqueKeyHashProof")]
 pub fn verify_identity_by_unique_public_key_hash(
     proof: &Uint8Array,
     js_public_key_hash: &Uint8Array,

--- a/packages/verify/src/verify_identity/verify_identity_contract_nonce.rs
+++ b/packages/verify/src/verify_identity/verify_identity_contract_nonce.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use dpp::prelude::IdentityNonce;
 use drive::drive::Drive;
 use drive::verify::RootHash;
@@ -27,10 +26,8 @@ impl VerifiedIdentityContractNonceWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "contractNonce")]
@@ -39,7 +36,7 @@ impl VerifiedIdentityContractNonceWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyIdentityContractNonce")]
+#[wasm_bindgen(js_name = "verifyIdentityContractNonceProof")]
 pub fn verify_identity_contract_nonce(
     proof: &Uint8Array,
     js_identity_id: &JsValue,

--- a/packages/verify/src/verify_identity/verify_identity_keys_by_identifier.rs
+++ b/packages/verify/src/verify_identity/verify_identity_keys_by_identifier.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::drive::Drive;
 use drive::drive::identity::key::fetch::{IdentityKeysRequest, KeyRequestType};
 use drive::verify::RootHash;
@@ -9,7 +8,7 @@ use pshenmic_dpp_partial_identity::PartialIdentityWASM;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
-#[wasm_bindgen(js_name = "verifiedIdentityKeysByIdentifierWASM")]
+#[wasm_bindgen(js_name = "VerifiedIdentityKeysByIdentifierWASM")]
 pub struct VerifiedIdentityKeysByIdentifierWASM {
     root_hash: RootHash,
     identity: Option<PartialIdentityWASM>,
@@ -28,10 +27,8 @@ impl VerifiedIdentityKeysByIdentifierWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "identity")]
@@ -39,7 +36,7 @@ impl VerifiedIdentityKeysByIdentifierWASM {
         self.identity.clone()
     }
 }
-#[wasm_bindgen(js_name = "verifyIdentityKeysByIdentifier")]
+#[wasm_bindgen(js_name = "verifyIdentityKeysByIdentifierProof")]
 pub fn verify_identity_keys_by_identifier(
     proof: &Uint8Array,
     js_identity_id: &JsValue,

--- a/packages/verify/src/verify_identity/verify_identity_nonce.rs
+++ b/packages/verify/src/verify_identity/verify_identity_nonce.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use dpp::prelude::IdentityNonce;
 use drive::drive::Drive;
 use drive::verify::RootHash;
@@ -27,10 +26,8 @@ impl VerifiedIdentityNonceWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "nonce")]
@@ -39,7 +36,7 @@ impl VerifiedIdentityNonceWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyIdentityNonce")]
+#[wasm_bindgen(js_name = "verifyIdentityNonceProof")]
 pub fn verify_identity_nonce(
     proof: &Uint8Array,
     js_identity_id: &JsValue,

--- a/packages/verify/src/verify_system/verify_epochs_info.rs
+++ b/packages/verify/src/verify_system/verify_epochs_info.rs
@@ -1,7 +1,6 @@
 use dpp::block::epoch::EpochIndex;
 use dpp::block::extended_epoch_info::ExtendedEpochInfo;
 use dpp::block::extended_epoch_info::v0::ExtendedEpochInfoV0Getters;
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::drive::Drive;
 use drive::verify::RootHash;
 use js_sys::Uint8Array;
@@ -81,10 +80,8 @@ impl VerifiedEpochsInfoWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "epochsInfo")]
@@ -93,7 +90,7 @@ impl VerifiedEpochsInfoWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyEpochsInfo")]
+#[wasm_bindgen(js_name = "verifyEpochsInfoProof")]
 pub fn verify_epochs_info(
     proof: &Uint8Array,
     current_epoch: u16,

--- a/packages/verify/src/verify_system/verify_total_credits.rs
+++ b/packages/verify/src/verify_system/verify_total_credits.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use dpp::fee::Credits;
 use dpp::prelude::CoreBlockHeight;
 use drive::drive::Drive;
@@ -27,10 +26,8 @@ impl VerifiedTotalCreditsWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "totalCredits")]
@@ -39,7 +36,7 @@ impl VerifiedTotalCreditsWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyTotalCredits")]
+#[wasm_bindgen(js_name = "verifyTotalCreditsProof")]
 pub fn verify_total_credits(
     proof: &Uint8Array,
     core_subsidy_halving_interval: u32,

--- a/packages/verify/src/verify_tokens/verify_token_balances_for_identities.rs
+++ b/packages/verify/src/verify_tokens/verify_token_balances_for_identities.rs
@@ -1,5 +1,4 @@
 use dpp::balances::credits::TokenAmount;
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::verify::RootHash;
 use js_sys::{Array, Object, Reflect, Uint8Array};
 use pshenmic_dpp_enums::platform::PlatformVersionWASM;
@@ -26,10 +25,8 @@ impl VerifiedTokenBalancesForIdentitiesWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "balances")]
@@ -38,7 +35,7 @@ impl VerifiedTokenBalancesForIdentitiesWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyTokenBalancesForIdentities")]
+#[wasm_bindgen(js_name = "verifyTokenBalancesForIdentitiesProof")]
 pub fn verify_token_balances_for_identities(
     proof: &Uint8Array,
     js_token_id: &JsValue,

--- a/packages/verify/src/verify_tokens/verify_token_contract_info.rs
+++ b/packages/verify/src/verify_tokens/verify_token_contract_info.rs
@@ -1,4 +1,3 @@
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use dpp::data_contract::TokenContractPosition;
 use dpp::tokens::contract_info::TokenContractInfo;
 use dpp::tokens::contract_info::v0::TokenContractInfoV0Accessors;
@@ -22,18 +21,18 @@ impl From<TokenContractInfo> for TokenContractInfoWASM {
 
 #[wasm_bindgen]
 impl TokenContractInfoWASM {
-    #[wasm_bindgen(js_name = "contractId")]
+    #[wasm_bindgen(getter = "contractId")]
     pub fn contract_id(&self) -> IdentifierWASM {
         self.0.contract_id().into()
     }
 
-    #[wasm_bindgen(js_name = "tokenContractPosition")]
+    #[wasm_bindgen(getter = "tokenContractPosition")]
     pub fn token_contract_position(&self) -> TokenContractPosition {
         self.0.token_contract_position()
     }
 }
 
-#[wasm_bindgen(js_name = "VerifiedTokenContractInfoWSAM")]
+#[wasm_bindgen(js_name = "VerifiedTokenContractInfoWASM")]
 pub struct VerifiedTokenContractInfoWASM {
     root_hash: RootHash,
     contract_info: Option<TokenContractInfoWASM>,
@@ -52,10 +51,8 @@ impl VerifiedTokenContractInfoWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "contractInfo")]
@@ -64,7 +61,7 @@ impl VerifiedTokenContractInfoWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyTokenContractInfo")]
+#[wasm_bindgen(js_name = "verifyTokenContractInfoProof")]
 pub fn verify_token_contract_info(
     proof: &Uint8Array,
     js_token_id: &JsValue,

--- a/packages/verify/src/verify_tokens/verify_token_total_supply.rs
+++ b/packages/verify/src/verify_tokens/verify_token_total_supply.rs
@@ -1,6 +1,5 @@
 use dpp::balances::credits::SignedTokenAmount;
 use dpp::balances::total_single_token_balance::TotalSingleTokenBalance;
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::drive::Drive;
 use drive::verify::RootHash;
 use js_sys::Uint8Array;
@@ -61,10 +60,8 @@ impl VerifiedTokenTotalSupplyWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "totalBalance")]
@@ -73,7 +70,7 @@ impl VerifiedTokenTotalSupplyWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyTokenTotalSupply")]
+#[wasm_bindgen(js_name = "verifyTokenTotalSupplyProof")]
 pub fn verify_token_total_supply(
     proof: &Uint8Array,
     js_token_id: &JsValue,

--- a/packages/verify/src/verify_tokens/verify_tokens_balances_for_identity.rs
+++ b/packages/verify/src/verify_tokens/verify_tokens_balances_for_identity.rs
@@ -1,5 +1,4 @@
 use dpp::balances::credits::TokenAmount;
-use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use drive::verify::RootHash;
 use js_sys::{Array, Object, Reflect, Uint8Array};
 use pshenmic_dpp_enums::platform::PlatformVersionWASM;
@@ -26,10 +25,8 @@ impl VerifiedTokensBalancesForIdentityWASM {
     }
 
     #[wasm_bindgen(getter = "rootHash")]
-    pub fn root_hash(&self) -> String {
-        let bytes: [u8; 32] = self.root_hash;
-
-        bytes.to_hex_string(Case::Lower)
+    pub fn root_hash(&self) -> Uint8Array {
+        Uint8Array::from(self.root_hash.as_slice())
     }
 
     #[wasm_bindgen(getter = "balances")]
@@ -38,7 +35,7 @@ impl VerifiedTokensBalancesForIdentityWASM {
     }
 }
 
-#[wasm_bindgen(js_name = "verifyTokensBalancesForIdentity")]
+#[wasm_bindgen(js_name = "verifyTokensBalancesForIdentityProof")]
 pub fn verify_tokens_balances_for_identity(
     proof: &Uint8Array,
     js_token_ids: &JsValue,

--- a/tests/IdentityCreateTransition.spec.cjs
+++ b/tests/IdentityCreateTransition.spec.cjs
@@ -5,13 +5,13 @@ const { default: wasm } = require('..')
 describe('IdentityCreateTransition', function () {
   describe('serialization / deserialization', function () {
     it('should allow to create transition', function () {
-      const transition = wasm.IdentityCreateTransitionWASM.default(0)
+      const transition = wasm.IdentityCreateTransitionWASM.default(1)
 
       assert.notEqual(transition.__wbg_ptr, 0)
     })
 
     it('should allow to serialize to bytes', function () {
-      const transition = wasm.IdentityCreateTransitionWASM.default(0)
+      const transition = wasm.IdentityCreateTransitionWASM.default(1)
 
       const bytes = transition.bytes()
 
@@ -29,37 +29,37 @@ describe('IdentityCreateTransition', function () {
 
   describe('getters', function () {
     it('should allow to get userFeeIncrease', function () {
-      const transition = wasm.IdentityCreateTransitionWASM.default(0)
+      const transition = wasm.IdentityCreateTransitionWASM.default(1)
 
       assert.equal(transition.userFeeIncrease, 0)
     })
 
     it('should allow to get AssetLock', function () {
-      const transition = wasm.IdentityCreateTransitionWASM.default(0)
+      const transition = wasm.IdentityCreateTransitionWASM.default(1)
 
       assert.notEqual(transition.assetLock.__wbg_ptr, 0)
     })
 
     it('should allow to get Identifier', function () {
-      const transition = wasm.IdentityCreateTransitionWASM.default(0)
+      const transition = wasm.IdentityCreateTransitionWASM.default(1)
 
       assert.equal(transition.getIdentifier().base58(), '11111111111111111111111111111111')
     })
 
     it('should allow to get PublicKeys', function () {
-      const transition = wasm.IdentityCreateTransitionWASM.default(0)
+      const transition = wasm.IdentityCreateTransitionWASM.default(1)
 
       assert.equal(transition.publicKeys.length, 0)
     })
 
     it('should allow to get signature', function () {
-      const transition = wasm.IdentityCreateTransitionWASM.default(0)
+      const transition = wasm.IdentityCreateTransitionWASM.default(1)
 
       assert.deepEqual(transition.signature, Uint8Array.from([]))
     })
 
     it('should allow to get signable bytes', function () {
-      const transition = wasm.IdentityCreateTransitionWASM.default(0)
+      const transition = wasm.IdentityCreateTransitionWASM.default(1)
 
       assert.equal(transition.getSignableBytes().length, 229)
     })
@@ -67,7 +67,7 @@ describe('IdentityCreateTransition', function () {
 
   describe('setters', function () {
     it('should allow to set the userFeeIncrease', function () {
-      const transition = wasm.IdentityCreateTransitionWASM.default(0)
+      const transition = wasm.IdentityCreateTransitionWASM.default(1)
 
       transition.userFeeIncrease = 100
 


### PR DESCRIPTION
# Issue
After v1.0.23 we found some mistakes in verify bindings

# Things done
- Bugfix and mistakes fix
- bump
- Fix protocol versions (now starts from v1=1 to v9=9)