### PR TITLE
Increase memory arena size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 static ALLOCATOR: talc::Talck<talc::locking::AssumeUnlockable, talc::ClaimOnOom> = unsafe {
     use core::{mem::MaybeUninit, ptr::addr_of_mut};
 
-    const MEMORY_SIZE: usize = 32 * 1024 * 1024;
+    const MEMORY_SIZE: usize = 128 * 1024 * 1024;
     static mut MEMORY: [MaybeUninit<u8>; MEMORY_SIZE] = [MaybeUninit::uninit(); MEMORY_SIZE];
     let span = talc::Span::from_array(addr_of_mut!(MEMORY));
     let oom_handler = { talc::ClaimOnOom::new(span) };


### PR DESCRIPTION
# Issue
RuntimeError: memory access out of bounds
    at wasm://wasm/007eef0a:wasm-function[2335]:0x160d03
    at wasm://wasm/007eef0a:wasm-function[220]:0x5b429
    at wasm://wasm/007eef0a:wasm-function[360]:0x83d14
    at wasm://wasm/007eef0a:wasm-function[1420]:0x1268a5