### PR TITLE
GZIP module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,9 @@ jobs:
 
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        components: fmt
+
+    - name: Install rustfmt component
+      run: rustup component add rustfmt
 
     - name: Add rustup WASM target
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
 
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: fmt
 
     - name: Add rustup WASM target
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: Install rustfmt component
+        run: rustup component add rustfmt
+
       - name: Add rustup WASM target
         run: |
           rustup target add wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.1.0-dev.3"
+version = "1.1.0-dev.4"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.1.0-dev.3"
+version = "1.1.0-dev.4"
 edition = "2024"
 rust-version = "1.85"
 

--- a/README.md
+++ b/README.md
@@ -18,18 +18,23 @@ ___
 ### Build JS
 `yarn build:full`
 
-**NOTE. If you want to use ES6 module without CJS, you need to run `yarn babel`**
-
 ### Build with binary instead base122
 `yarn build:raw`
 Now you can import `.js` with base122 buffer for WebAssembly module, or binary which smaller
 ___
 ## Why you need to use `pshenmic-dpp` instead `wasm-dpp`
 
-- `pshenmic-dpp` weighs much less, currently taking up only 3.9 mb in base122 format
+- `pshenmic-dpp` weighs much less, currently taking up only 1.4mb(\*) or 2.2mb(\*) in base122 format with GZIP
 - You can build only necessary modules by removing imports from `lib.rs` before building
 - More accurately replicates `rs-dpp`
 - Some sugar, like enums, which you can pass in string with any case or just use numbers
+
+**(\*)** \- This module contains 2 builds for wasm js layer:
+- JS without bundling or GZIP (2.2mb)
+- Bundled JS with GZIP (1.4mb)
+
+These variations can be imported depending on requirements.
+In both cases, the binary wasm data will be compressed using gzip.
 ___
 
 ## Current features
@@ -129,8 +134,9 @@ yarn tests
 
 ## Example
 
+This example show how to synchronously import module with size 2.2mb  
 ```js
-import wasm from pshenmic_dpp';
+import wasm from 'pshenmic_dpp';
 
 const document = new wasm.DocumentWASM(
     {
@@ -168,4 +174,20 @@ st.sign(privKey, pubKey)
 
 console.log(st.toBytes())
 console.log(st.hash(false))
+```
+
+This example show how to asynchronously import module with size 1.4mb
+```js
+const {default: initWASM} = require('pshenmic-dpp/initAsync')
+
+async function main() {
+  let wasm = await initWASM()
+
+  const dataContractIdentifier = new wasm.IdentifierWASM('6QMfQTdKpC3Y9uWBcTwXeY3KdzRLDqASUsDnQ4MEc9XC')
+  const ownerIdentifier = new wasm.IdentifierWASM('B7kcE1juMBWEWkuYRJhVdAE2e6RaevrGxRsa1DrLCpQH')
+
+  const documentInstance = new wasm.DocumentWASM(document, 'documentTypeName', BigInt(1), dataContractIdentifier, ownerIdentifier)
+}
+
+main().catch(console.error)
 ```

--- a/lib/base122.js
+++ b/lib/base122.js
@@ -18,7 +18,7 @@ const kShortened = 0b111 // Uses the illegal index to signify the last two-byte 
  * with raw data bytes or a string of bytes (i.e. the type of argument to btoa())
  * @returns {Uint8Array} The data in a regular array representing byte values.
  */
-export function decodeBase122 (base122Data) {
+export function decode (base122Data) {
   const strData = typeof (base122Data) === 'string' ? base122Data : utf8DataToString(base122Data)
   const decoded = []
   const decodedIndex = 0

--- a/lib/base122.js
+++ b/lib/base122.js
@@ -21,7 +21,6 @@ const kShortened = 0b111 // Uses the illegal index to signify the last two-byte 
 export function decode (base122Data) {
   const strData = typeof (base122Data) === 'string' ? base122Data : utf8DataToString(base122Data)
   const decoded = []
-  const decodedIndex = 0
   let curByte = 0
   let bitOfByte = 0
 
@@ -47,7 +46,7 @@ export function decode (base122Data) {
       const illegalIndex = (c >>> 8) & 7 // 7 = 0b111.
       // We have to first check if this is a shortened two-byte character, i.e. if it only
       // encodes <= 7 bits.
-      if (illegalIndex != kShortened) push7(kIllegals[illegalIndex])
+      if (illegalIndex !== kShortened) push7(kIllegals[illegalIndex])
       // Always push the rest.
       push7(c & 127)
     } else {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,8 +1,8 @@
-import * as DPP from './pshenmic_dpp';
+import * as DPP from './pshenmic_dpp.js';
 
-export * from './pshenmic_dpp'
+export * from './pshenmic_dpp.js'
 
-export * from './base122'
+export * from './base122.js'
 
 export default dpp;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,46 +1,13 @@
+import * as DPP from './pshenmic_dpp.js'
 import {default as wasmBytes} from './pshenmic_dpp_bg.js'
-import {default as wasmInterfaceBytes} from './pshenmic_dpp.js'
 import {decode} from './base122.js'
+import {decompressSync} from "fflate"
 
 export * from './base122.js'
+export * from './pshenmic_dpp.js'
 
-const isNode = () =>
-  typeof process !== 'undefined' &&
-  !!process.versions &&
-  !!process.versions.node;
+const bytes = new Uint8Array(decode(wasmBytes))
 
-const interfaceBytes = new Uint8Array(decode(wasmInterfaceBytes));
-const interfaceBlob = new Blob([interfaceBytes]);
+const dppInstance = DPP.initSync({module: decompressSync(bytes)})
 
-async function main() {
-  const decompressionStream = new DecompressionStream('gzip');
-  const decompressedStream = interfaceBlob.stream().pipeThrough(decompressionStream);
-  const decompressedResponse = new Response(decompressedStream);
-  const moduleText = await decompressedResponse.text();
-
-  if(isNode()) {
-    const moduleUrl = 'data:text/javascript,' + encodeURIComponent(moduleText);
-
-    const module = await import(moduleUrl);
-
-    return module;
-  } else {
-    const blob = new Blob([moduleText], { type: 'application/javascript' });
-    const moduleUrl = URL.createObjectURL(blob);
-
-    const module = await import(moduleUrl);
-
-    return module;
-  }
-}
-
-export default main
-
-
-// export * from './pshenmic_dpp.js'
-
-// const bytes = new Uint8Array(decode(wasmBytes))
-//
-// const dppInstance = DPP.initSync({module: decompressSync(bytes)})
-//
-// export default DPP
+export default DPP

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,38 @@ import {decode} from './base122.js'
 
 export * from './base122.js'
 
-console.log()
+const isNode = () =>
+  typeof process !== 'undefined' &&
+  !!process.versions &&
+  !!process.versions.node;
+
+const interfaceBytes = new Uint8Array(decode(wasmInterfaceBytes));
+const interfaceBlob = new Blob([interfaceBytes]);
+
+async function main() {
+  const decompressionStream = new DecompressionStream('gzip');
+  const decompressedStream = interfaceBlob.stream().pipeThrough(decompressionStream);
+  const decompressedResponse = new Response(decompressedStream);
+  const moduleText = await decompressedResponse.text();
+
+  if(isNode()) {
+    const moduleUrl = 'data:text/javascript,' + encodeURIComponent(moduleText);
+
+    const module = await import(moduleUrl);
+
+    return module;
+  } else {
+    const blob = new Blob([moduleText], { type: 'application/javascript' });
+    const moduleUrl = URL.createObjectURL(blob);
+
+    const module = await import(moduleUrl);
+
+    return module;
+  }
+}
+
+export default main
+
 
 // export * from './pshenmic_dpp.js'
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,15 @@
-import * as DPP from './pshenmic_dpp.js'
-import { default as wasmBytes } from './pshenmic_dpp_bg.js'
-import { decodeBase122 } from './base122.js'
+import {default as wasmBytes} from './pshenmic_dpp_bg.js'
+import {default as wasmInterfaceBytes} from './pshenmic_dpp.js'
+import {decode} from './base122.js'
 
 export * from './base122.js'
-export * from './pshenmic_dpp.js'
 
-const bytes = new Uint8Array(decodeBase122(wasmBytes))
+console.log()
 
-const dppInstance = DPP.initSync({ module: bytes })
+// export * from './pshenmic_dpp.js'
 
-export default DPP
+// const bytes = new Uint8Array(decode(wasmBytes))
+//
+// const dppInstance = DPP.initSync({module: decompressSync(bytes)})
+//
+// export default DPP

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,13 @@
 import * as DPP from './pshenmic_dpp.js'
-import {default as wasmBytes} from './pshenmic_dpp_bg.js'
-import {decode} from './base122.js'
-import {decompressSync} from "fflate"
+import wasmBytes from './pshenmic_dpp_bg.js'
+import { decode } from './base122.js'
+import { decompressSync } from 'fflate'
 
 export * from './base122.js'
 export * from './pshenmic_dpp.js'
 
 const bytes = new Uint8Array(decode(wasmBytes))
 
-const dppInstance = DPP.initSync({module: decompressSync(bytes)})
+DPP.initSync({ module: decompressSync(bytes) })
 
 export default DPP

--- a/lib/initAsync.d.ts
+++ b/lib/initAsync.d.ts
@@ -1,4 +1,3 @@
-import * as DPP from './pshenmic_dpp.js';
 import type {DashPlatformProtocolWASM} from "./index.d.ts";
 
 declare function initModule(): Promise<DashPlatformProtocolWASM>

--- a/lib/initAsync.d.ts
+++ b/lib/initAsync.d.ts
@@ -1,0 +1,7 @@
+import * as DPP from './pshenmic_dpp.js';
+import type {DashPlatformProtocolWASM} from "./index.d.ts";
+
+declare function initModule(): Promise<DashPlatformProtocolWASM>
+
+export default initModule;
+export type { DashPlatformProtocolWASM } from './index.d.ts';

--- a/lib/initAsync.js
+++ b/lib/initAsync.js
@@ -1,11 +1,11 @@
 import {default as initWASM} from './initWASM.js';
 import {default as initWASMInterface} from './initInterface.js';
 
-let dpp
+declare let dpp
 
 async function initModule() {
-  const wasm = await initWASM;
-  const wasmInterface = await initWASMInterface;
+  const wasm = await initWASM();
+  const wasmInterface = await initWASMInterface();
 
   dpp = wasmInterface.initSync(wasm)
 
@@ -13,3 +13,4 @@ async function initModule() {
 }
 
 export default initModule;
+export {dpp};

--- a/lib/initAsync.js
+++ b/lib/initAsync.js
@@ -1,19 +1,20 @@
-import {default as initWASM} from './initWASM.js';
-import {default as initWASMInterface} from './initInterface.js';
+import initWASM from './initWASM.js'
+import initWASMInterface from './initInterface.js'
 
+// eslint-disable-next-line
 let dpp
 
 /**
  * Asynchronously initialization for compressed module (reduced size)
  * @returns {Promise<*>}
  */
-async function initModule() {
-  const wasm = await initWASM();
-  const wasmInterface = await initWASMInterface();
+async function initModule () {
+  const wasm = await initWASM()
+  const wasmInterface = await initWASMInterface()
 
   dpp = wasmInterface.initSync(wasm)
 
   return wasmInterface
 }
 
-export default initModule;
+export default initModule

--- a/lib/initAsync.js
+++ b/lib/initAsync.js
@@ -1,8 +1,12 @@
 import {default as initWASM} from './initWASM.js';
 import {default as initWASMInterface} from './initInterface.js';
 
-declare let dpp
+let dpp
 
+/**
+ * Asynchronously initialization for compressed module (reduced size)
+ * @returns {Promise<*>}
+ */
 async function initModule() {
   const wasm = await initWASM();
   const wasmInterface = await initWASMInterface();
@@ -13,4 +17,3 @@ async function initModule() {
 }
 
 export default initModule;
-export {dpp};

--- a/lib/initAsync.js
+++ b/lib/initAsync.js
@@ -1,0 +1,15 @@
+import {default as initWASM} from './initWASM.js';
+import {default as initWASMInterface} from './initInterface.js';
+
+let dpp
+
+async function initModule() {
+  const wasm = await initWASM;
+  const wasmInterface = await initWASMInterface;
+
+  dpp = wasmInterface.initSync(wasm)
+
+  return wasmInterface
+}
+
+export default initModule;

--- a/lib/initInterface.d.ts
+++ b/lib/initInterface.d.ts
@@ -1,0 +1,5 @@
+import type {DashPlatformProtocolWASM} from "./index.d.ts";
+
+declare function initModule(): Promise<DashPlatformProtocolWASM>
+
+export default initModule;

--- a/lib/initInterface.js
+++ b/lib/initInterface.js
@@ -1,0 +1,48 @@
+import {default as wasmInterfaceBytes} from './pshenmic_dpp.js';
+import {decode} from './base122.js';
+
+export * from './base122.js';
+
+let modulePromise;
+
+const isNode = () =>
+  typeof process !== 'undefined' &&
+  !!process.versions &&
+  !!process.versions.node;
+
+const interfaceBytes = new Uint8Array(decode(wasmInterfaceBytes));
+const interfaceBlob = new Blob([interfaceBytes]);
+
+async function initInterface() {
+  const decompressionStream = new DecompressionStream('gzip');
+  const decompressedStream = interfaceBlob.stream().pipeThrough(decompressionStream);
+  const decompressedResponse = new Response(decompressedStream);
+  const moduleText = await decompressedResponse.text();
+
+  let module;
+  if (isNode()) {
+    const vm = await import('vm');
+
+    const context = vm.createContext({
+      TextDecoder: TextDecoder
+    });
+    const vmModule = new vm.Script(moduleText);
+
+    vmModule.runInContext(context);
+
+    module = context['pshenmic-dpp']
+  } else {
+    const blob = new Blob([moduleText], {type: 'application/javascript'});
+    const moduleUrl = URL.createObjectURL(blob);
+
+    module = await import(moduleUrl);
+
+    URL.revokeObjectURL(moduleUrl);
+  }
+
+  return module;
+}
+
+modulePromise = initInterface();
+
+export default modulePromise;

--- a/lib/initInterface.js
+++ b/lib/initInterface.js
@@ -1,4 +1,4 @@
-import {default as wasmInterfaceBytes} from './pshenmic_dpp.js';
+import {default as wasmInterfaceBytes} from './pshenmic_dpp_zipped.js';
 import {decode} from './base122.js';
 
 export * from './base122.js';
@@ -24,7 +24,8 @@ async function initInterface() {
     const vm = await import('vm');
 
     const context = vm.createContext({
-      TextDecoder: TextDecoder
+      crypto,
+      TextDecoder,
     });
     const vmModule = new vm.Script(moduleText);
 

--- a/lib/initInterface.js
+++ b/lib/initInterface.js
@@ -43,6 +43,4 @@ async function initInterface() {
   return module;
 }
 
-modulePromise = initInterface();
-
-export default modulePromise;
+export default initInterface;

--- a/lib/initInterface.js
+++ b/lib/initInterface.js
@@ -1,47 +1,45 @@
-import {default as wasmInterfaceBytes} from './pshenmic_dpp_zipped.js';
-import {decode} from './base122.js';
+import wasmInterfaceBytes from './pshenmic_dpp_zipped.js'
+import { decode } from './base122.js'
 
-export * from './base122.js';
-
-let modulePromise;
+export * from './base122.js'
 
 const isNode = () =>
   typeof process !== 'undefined' &&
   !!process.versions &&
-  !!process.versions.node;
+  !!process.versions.node
 
-const interfaceBytes = new Uint8Array(decode(wasmInterfaceBytes));
-const interfaceBlob = new Blob([interfaceBytes]);
+const interfaceBytes = new Uint8Array(decode(wasmInterfaceBytes))
+const interfaceBlob = new Blob([interfaceBytes])
 
-async function initInterface() {
-  const decompressionStream = new DecompressionStream('gzip');
-  const decompressedStream = interfaceBlob.stream().pipeThrough(decompressionStream);
-  const decompressedResponse = new Response(decompressedStream);
-  const moduleText = await decompressedResponse.text();
+async function initInterface () {
+  const decompressionStream = new DecompressionStream('gzip')
+  const decompressedStream = interfaceBlob.stream().pipeThrough(decompressionStream)
+  const decompressedResponse = new Response(decompressedStream)
+  const moduleText = await decompressedResponse.text()
 
-  let module;
+  let module
   if (isNode()) {
-    const vm = await import('vm');
+    const vm = await import('vm')
 
     const context = vm.createContext({
       crypto,
-      TextDecoder,
-    });
-    const vmModule = new vm.Script(moduleText);
+      TextDecoder
+    })
+    const vmModule = new vm.Script(moduleText)
 
-    vmModule.runInContext(context);
+    vmModule.runInContext(context)
 
     module = context['pshenmic-dpp']
   } else {
-    const blob = new Blob([moduleText], {type: 'application/javascript'});
-    const moduleUrl = URL.createObjectURL(blob);
+    const blob = new Blob([moduleText], { type: 'application/javascript' })
+    const moduleUrl = URL.createObjectURL(blob)
 
-    module = await import(moduleUrl);
+    module = await import(moduleUrl)
 
-    URL.revokeObjectURL(moduleUrl);
+    URL.revokeObjectURL(moduleUrl)
   }
 
-  return module;
+  return module
 }
 
-export default initInterface;
+export default initInterface

--- a/lib/initWASM.d.ts
+++ b/lib/initWASM.d.ts
@@ -1,0 +1,2 @@
+declare function _default(): Promise<ArrayBuffer>;
+export default _default;

--- a/lib/initWASM.js
+++ b/lib/initWASM.js
@@ -1,0 +1,27 @@
+import {default as wasmBytes} from './pshenmic_dpp_bg.js';
+import {decode} from './base122.js';
+
+export * from './base122.js';
+
+let modulePromise;
+
+const isNode = () =>
+  typeof process !== 'undefined' &&
+  !!process.versions &&
+  !!process.versions.node;
+
+const interfaceBytes = new Uint8Array(decode(wasmBytes));
+const interfaceBlob = new Blob([interfaceBytes]);
+
+async function initWASM() {
+  const decompressionStream = new DecompressionStream('gzip');
+  const decompressedStream = interfaceBlob.stream().pipeThrough(decompressionStream);
+  const decompressedResponse = new Response(decompressedStream);
+  const module = await decompressedResponse.arrayBuffer();
+
+  return module;
+}
+
+modulePromise = initWASM();
+
+export default modulePromise;

--- a/lib/initWASM.js
+++ b/lib/initWASM.js
@@ -1,29 +1,28 @@
-import {default as wasmBytes} from './pshenmic_dpp_bg.js';
-import {decode} from './base122.js';
+import wasmBytes from './pshenmic_dpp_bg.js'
+import { decode } from './base122.js'
 
-export * from './base122.js';
+export * from './base122.js'
 
-let modulePromise;
-
+// eslint-disable-next-line
 const isNode = () =>
   typeof process !== 'undefined' &&
   !!process.versions &&
-  !!process.versions.node;
+  !!process.versions.node
 
-const interfaceBytes = new Uint8Array(decode(wasmBytes));
-const interfaceBlob = new Blob([interfaceBytes]);
+const interfaceBytes = new Uint8Array(decode(wasmBytes))
+const interfaceBlob = new Blob([interfaceBytes])
 
 /**
  * Convert wasm bin string to Uint8Array with decompression via DecompressionStream
  * @returns {Promise<ArrayBuffer>}
  */
-async function initWASM() {
-  const decompressionStream = new DecompressionStream('gzip');
-  const decompressedStream = interfaceBlob.stream().pipeThrough(decompressionStream);
-  const decompressedResponse = new Response(decompressedStream);
-  const module = await decompressedResponse.arrayBuffer();
+async function initWASM () {
+  const decompressionStream = new DecompressionStream('gzip')
+  const decompressedStream = interfaceBlob.stream().pipeThrough(decompressionStream)
+  const decompressedResponse = new Response(decompressedStream)
+  const module = await decompressedResponse.arrayBuffer()
 
-  return module;
+  return module
 }
 
-export default initWASM;
+export default initWASM

--- a/lib/initWASM.js
+++ b/lib/initWASM.js
@@ -22,6 +22,4 @@ async function initWASM() {
   return module;
 }
 
-modulePromise = initWASM();
-
-export default modulePromise;
+export default initWASM;

--- a/lib/initWASM.js
+++ b/lib/initWASM.js
@@ -13,6 +13,10 @@ const isNode = () =>
 const interfaceBytes = new Uint8Array(decode(wasmBytes));
 const interfaceBlob = new Blob([interfaceBytes]);
 
+/**
+ * Convert wasm bin string to Uint8Array with decompression via DecompressionStream
+ * @returns {Promise<ArrayBuffer>}
+ */
 async function initWASM() {
   const decompressionStream = new DecompressionStream('gzip');
   const decompressedStream = interfaceBlob.stream().pipeThrough(decompressionStream);

--- a/package.json
+++ b/package.json
@@ -3,15 +3,17 @@
   "version": "1.1.0-dev.3",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/owl352/pshenmic-dpp"
   },
   "scripts": {
     "build:bin": "./scripts/build.sh",
-    "build:js": "./scripts/build-js.sh",
-    "build:full": "./scripts/build.sh && ./scripts/build-js.sh",
+    "build:js": "npm run bundle && ./scripts/build-js.sh",
+    "build:full": "./scripts/build.sh && npm run bundle && ./scripts/build-js.sh",
     "build:raw": "./scripts/build.sh && RAW=true ./scripts/build-js.sh",
+    "bundle": "rollup -c",
     "docs": "ts-node utils/generate-docs.ts && typedoc",
     "babel": "babel dist/wasm --out-dir dist/cjs/wasm",
     "tests": "mocha ./tests/*.spec.cjs",
@@ -27,20 +29,20 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@babel/cli": "^7.27.0",
-    "@babel/core": "^7.26.10",
-    "@babel/plugin-transform-modules-commonjs": "^7.26.3",
-    "@babel/plugin-transform-runtime": "^7.26.10",
-    "@babel/preset-env": "^7.26.9",
+    "@rollup/plugin-terser": "^0.4.4",
     "@scure/base": "^1.2.4",
     "@types/node": "^24.0.13",
     "core-js": "^3.41.0",
     "mocha": "^11.1.0",
     "path": "^0.12.7",
+    "rollup": "^4.52.2",
     "standard": "^17.1.2",
     "ts-morph": "^26.0.0",
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.7",
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "fflate": "^0.8.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "dist/wasm",
     "tests/"
   ],
+  "exports": {
+    ".": "./dist/wasm/index.js",
+    "./initAsync": "./dist/wasm/initAsync.js"
+  },
   "author": "owl352",
   "license": "ISC",
   "description": "",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:full": "./scripts/build.sh && npm run bundle && ./scripts/build-js.sh",
     "build:raw": "./scripts/build.sh && RAW=true ./scripts/build-js.sh",
     "bundle": "rollup -c",
-    "docs": "ts-node utils/generate-docs.ts && typedoc",
+    "docs": "tsx utils/generate-docs.ts && typedoc",
     "babel": "babel dist/wasm --out-dir dist/cjs/wasm",
     "tests": "mocha ./tests/*.spec.cjs",
     "lint": "cargo fmt",
@@ -38,7 +38,7 @@
     "rollup": "^4.52.2",
     "standard": "^17.1.2",
     "ts-morph": "^26.0.0",
-    "ts-node": "^10.9.2",
+    "tsx": "^4.20.6",
     "typedoc": "^0.28.7",
     "typescript": "^5.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.1.0-dev.3",
+  "version": "1.1.0-dev.4",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "type": "module",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,10 @@
+export default {
+  input: 'wasm/pshenmic_dpp.js',
+  output: {
+    file: 'wasm/pshenmic_dpp_bundle.js',
+    format: 'umd',
+    name: 'pshenmic-dpp',
+    exports: 'named',
+    compact: true,
+  },
+};

--- a/scripts/build-js.sh
+++ b/scripts/build-js.sh
@@ -47,7 +47,8 @@ if [[ "${RAW}" == "true" ]]; then
   cp $WASM_BINARY_PATH $DIST_WASM_BINARY_RAW
 else
   echo "Converting wasm binary into base122 module"
-  npm run convert:base122 --silent "$WASM_BINARY_PATH" > "$DIST_WASM_BINARY_BASE_64"
+  npm run convert:base122 --silent "$WASM_BINARY_PATH" "$DIST_WASM_BINARY_BASE_64"
+  npm run convert:base122 --silent "$WASM_JS_CODE_PATH" "$WASM_JS_CODE_PATH"
   cp $MODULE_BASE122 $DIST_BASE122
 fi
 

--- a/scripts/build-js.sh
+++ b/scripts/build-js.sh
@@ -6,6 +6,7 @@ DIST_WASM_DIR="$DIST_DIR/wasm"
 DIST_WASM_BINARY_BASE_64="$DIST_WASM_DIR/pshenmic_dpp_bg.js"
 DIST_WASM_BINARY_RAW="$DIST_WASM_DIR/pshenmic_dpp_bg.wasm"
 DIST_WASM_JS="$DIST_WASM_DIR/pshenmic_dpp.js"
+DIST_WASM_JS_ZIPPED="$DIST_WASM_DIR/pshenmic_dpp_zipped.js"
 DIST_WASM_JS_INDEX="$DIST_WASM_DIR/index.js"
 DIST_WASM_JS_SNIPPETS="$DIST_WASM_DIR/snippets"
 DIST_WASM_TS_BG="$DIST_WASM_DIR/pshenmic_dpp_bg.wasm.d.ts"
@@ -17,6 +18,7 @@ DIST_BASE122="$DIST_WASM_DIR/base122.js"
 ## Paths to wasm files produced by wasm-bindgen
 WASM_DIR="$PWD/wasm"
 WASM_JS_CODE_PATH="$WASM_DIR/pshenmic_dpp.js"
+WASM_JS_CODE_ZIPPED_PATH="$WASM_DIR/pshenmic_dpp_bundle_zip.js"
 WASM_JS_SNIPPETS="$WASM_DIR/snippets"
 WASM_BINARY_PATH="$WASM_DIR/pshenmic_dpp_bg.wasm"
 WASM_TS_BG_CODE_PATH="$WASM_DIR/pshenmic_dpp_bg.wasm.d.ts"
@@ -36,6 +38,7 @@ rm -rf $DIST_WASM_JS_SNIPPETS
 rm -rf $DIST_WASM_BINARY_RAW
 rm -rf $DIST_WASM_JS_INDEX
 rm -rf $DIST_WASM_JS
+rm -rf $DIST_WASM_JS_ZIPPED
 
 rm -rf $DIST_WASM_TS_INDEX
 rm -rf $DIST_WASM_TS_BG
@@ -48,12 +51,13 @@ if [[ "${RAW}" == "true" ]]; then
 else
   echo "Converting wasm binary into base122 module"
   npm run convert:base122 --silent "$WASM_BINARY_PATH" "$DIST_WASM_BINARY_BASE_64"
-  npm run convert:base122 --silent "$WASM_JS_CODE_PATH" "$WASM_JS_CODE_PATH"
+  npm run convert:base122 --silent "$WASM_JS_CODE_PATH" "$WASM_JS_CODE_ZIPPED_PATH"
   cp $MODULE_BASE122 $DIST_BASE122
 fi
 
 echo "Copying ES module to dist"
 cp $WASM_JS_CODE_PATH $DIST_WASM_JS
+cp $WASM_JS_CODE_ZIPPED_PATH $DIST_WASM_JS_ZIPPED
 cp -R $WASM_JS_SNIPPETS $DIST_WASM_JS_SNIPPETS
 
 
@@ -75,7 +79,7 @@ fi
 
 
 echo "Cleaning wasm build"
-rm -rf $WASM_DIR
+#rm -rf $WASM_DIR
 
 echo "Total build size: "
 du -sh $DIST_WASM_DIR

--- a/scripts/build-js.sh
+++ b/scripts/build-js.sh
@@ -79,7 +79,7 @@ fi
 
 
 echo "Cleaning wasm build"
-#rm -rf $WASM_DIR
+rm -rf $WASM_DIR
 
 echo "Total build size: "
 du -sh $DIST_WASM_DIR

--- a/scripts/build-js.sh
+++ b/scripts/build-js.sh
@@ -18,6 +18,7 @@ DIST_BASE122="$DIST_WASM_DIR/base122.js"
 ## Paths to wasm files produced by wasm-bindgen
 WASM_DIR="$PWD/wasm"
 WASM_JS_CODE_PATH="$WASM_DIR/pshenmic_dpp.js"
+WASM_JS_CODE_BUNDLE_PATH="$WASM_DIR/pshenmic_dpp_bundle.js"
 WASM_JS_CODE_ZIPPED_PATH="$WASM_DIR/pshenmic_dpp_bundle_zip.js"
 WASM_JS_SNIPPETS="$WASM_DIR/snippets"
 WASM_BINARY_PATH="$WASM_DIR/pshenmic_dpp_bg.wasm"
@@ -46,14 +47,10 @@ rm -rf $DIST_WASM_TS
 
 ## Converting wasm into base64 and saving it to dist folder
 
-if [[ "${RAW}" == "true" ]]; then
-  cp $WASM_BINARY_PATH $DIST_WASM_BINARY_RAW
-else
-  echo "Converting wasm binary into base122 module"
-  npm run convert:base122 --silent "$WASM_BINARY_PATH" "$DIST_WASM_BINARY_BASE_64"
-  npm run convert:base122 --silent "$WASM_JS_CODE_PATH" "$WASM_JS_CODE_ZIPPED_PATH"
-  cp $MODULE_BASE122 $DIST_BASE122
-fi
+echo "Converting wasm binary into base122 module"
+npm run convert:base122 --silent "$WASM_BINARY_PATH" "$DIST_WASM_BINARY_BASE_64"
+npm run convert:base122 --silent "$WASM_JS_CODE_BUNDLE_PATH" "$WASM_JS_CODE_ZIPPED_PATH"
+cp $MODULE_BASE122 $DIST_BASE122
 
 echo "Copying ES module to dist"
 cp $WASM_JS_CODE_PATH $DIST_WASM_JS

--- a/tests/AssetLockProof.spec.cjs
+++ b/tests/AssetLockProof.spec.cjs
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const { describe, it } = require('mocha')
 const { instantLockBytes, transactionBytes } = require('./mocks/Locks')
-const { default: wasm } = require('..')
+const { default: wasm } = require('pshenmic-dpp')
 
 describe('AssetLockProof', function () {
   describe('serialization / deserialization', function () {

--- a/tests/AsyncImportTest.spec.cjs
+++ b/tests/AsyncImportTest.spec.cjs
@@ -1,0 +1,930 @@
+const assert = require('assert')
+const { describe, it } = require('mocha')
+const {
+  document, dataContractId, ownerId, documentTypeName, revision, dataContractValue, id, document2, documentBytes
+} = require('./mocks/Document/index.js')
+const { fromHexString } = require('./utils/hex')
+const {default: initWASM} = require('pshenmic-dpp/initAsync')
+
+let wasm
+
+describe('Async Import', function () {
+  before(async () => {
+    wasm = await initWASM();
+  })
+
+  describe('Document', function () {
+    describe('serialization / deserialization', function () {
+      it('should allows to create Document from values', function () {
+        const dataContractIdentifier = new wasm.IdentifierWASM(dataContractId)
+        const ownerIdentifier = new wasm.IdentifierWASM(ownerId)
+
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractIdentifier, ownerIdentifier)
+
+        assert.notEqual(documentInstance.__wbg_ptr, 0)
+      })
+
+      it('should allows to create Document from values with custom id', function () {
+        const dataContractIdentifier = new wasm.IdentifierWASM(dataContractId)
+        const ownerIdentifier = new wasm.IdentifierWASM(ownerId)
+        const identifier = new wasm.IdentifierWASM(id)
+
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractIdentifier, ownerIdentifier, identifier)
+
+        assert.notEqual(documentInstance.__wbg_ptr, 0)
+      })
+
+      it('should allows to create Document from bytes and convert to bytes', function () {
+        const dataContract = wasm.DataContractWASM.fromValue(dataContractValue, false)
+        const documentInstance = wasm.DocumentWASM.fromBytes(fromHexString(documentBytes), dataContract, 'note')
+
+        const bytes = documentInstance.bytes(dataContract, wasm.PlatformVersionWASM.PLATFORM_V1)
+
+        assert.equal(documentInstance.dataContractId.base58(), dataContract.id.base58())
+        assert.deepEqual(bytes, fromHexString(documentBytes))
+        assert.notEqual(dataContract.__wbg_ptr, 0)
+      })
+    })
+
+    describe('getters', function () {
+      it('should return document id', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        assert.deepEqual(documentInstance.id.base58(), id)
+      })
+
+      it('should return owner id', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        assert.deepEqual(documentInstance.ownerId.base58(), ownerId)
+      })
+
+      it('should return data contract id', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        assert.deepEqual(documentInstance.dataContractId.base58(), dataContractId)
+      })
+
+      it('should return properties', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        assert.deepEqual(documentInstance.properties, document)
+      })
+
+      it('should return revision', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        assert.deepEqual(documentInstance.revision, revision)
+      })
+    })
+
+    describe('setters', function () {
+      it('should allow to set document id', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        documentInstance.id = ownerId
+
+        assert.deepEqual(documentInstance.id.base58(), ownerId)
+      })
+
+      it('should allow to set document owner id', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        documentInstance.ownerId = id
+
+        assert.deepEqual(documentInstance.ownerId.base58(), id)
+      })
+
+      it('should allow to set entropy', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const newEntropy = new Array(documentInstance.entropy.length).fill(0)
+
+        documentInstance.entropy = newEntropy
+
+        assert.deepEqual(Array.from(documentInstance.entropy), newEntropy)
+      })
+
+      it('should allow to set properties', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        documentInstance.properties = document2
+
+        assert.deepEqual(documentInstance.properties, document2)
+      })
+
+      it('should allow to set revision', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const newRevision = BigInt(1000)
+
+        documentInstance.revision = newRevision
+
+        assert.deepEqual(documentInstance.revision, newRevision)
+      })
+
+      it('should allow to set created at', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const createdAt = BigInt(new Date(1123).getTime())
+
+        documentInstance.createdAt = createdAt
+
+        assert.deepEqual(documentInstance.createdAt, createdAt)
+      })
+
+      it('should allow to set updated at', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const updatedAt = BigInt(new Date(1123).getTime())
+
+        documentInstance.updatedAt = updatedAt
+
+        assert.deepEqual(documentInstance.updatedAt, updatedAt)
+      })
+
+      it('should allow to set transferred at', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const transferredAt = BigInt(new Date(11231).getTime())
+
+        documentInstance.transferredAt = transferredAt
+
+        assert.deepEqual(documentInstance.transferredAt, transferredAt)
+      })
+
+      it('should allow to set create at Block Height', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const createdAtHeight = BigInt(9172)
+
+        documentInstance.createdAtBlockHeight = createdAtHeight
+
+        assert.deepEqual(documentInstance.createdAtBlockHeight, createdAtHeight)
+      })
+
+      it('should allow to set updated at Block Height', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const updatedAtHeight = BigInt(9172)
+
+        documentInstance.updatedAtBlockHeight = updatedAtHeight
+
+        assert.deepEqual(documentInstance.updatedAtBlockHeight, updatedAtHeight)
+      })
+
+      it('should allow to set transferred at Block Height', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const transferredAtHeight = BigInt(9172)
+
+        documentInstance.transferredAtBlockHeight = transferredAtHeight
+
+        assert.deepEqual(documentInstance.transferredAtBlockHeight, transferredAtHeight)
+      })
+
+      it('should allow to set create at core Block Height', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const createdAtHeight = 91721
+
+        documentInstance.createdAtCoreBlockHeight = createdAtHeight
+
+        assert.deepEqual(documentInstance.createdAtCoreBlockHeight, createdAtHeight)
+      })
+
+      it('should allow to set updated at Block Height', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const updatedAtHeight = 91722
+
+        documentInstance.updatedAtCoreBlockHeight = updatedAtHeight
+
+        assert.deepEqual(documentInstance.updatedAtCoreBlockHeight, updatedAtHeight)
+      })
+
+      it('should allow to set transferred at Block Height', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const transferredAtHeight = 91723
+
+        documentInstance.transferredAtCoreBlockHeight = transferredAtHeight
+
+        assert.deepEqual(documentInstance.transferredAtCoreBlockHeight, transferredAtHeight)
+      })
+
+      it('should allow to set document type name', () => {
+        const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+
+        const newDocumentTypeName = 'bbbb'
+
+        documentInstance.documentTypeName = newDocumentTypeName
+
+        assert.deepEqual(documentInstance.documentTypeName, newDocumentTypeName)
+      })
+    })
+
+    describe('static', function () {
+      it('should allow to generate id', () => {
+        const generatedId = wasm.DocumentWASM.generateId('note', ownerId, dataContractId)
+
+        assert.equal(Array.from(generatedId).length, 32)
+      })
+    })
+  })
+
+  describe('DocumentsTransitions', function () {
+    describe('serialization / deserialization', function () {
+      describe('document Create transition', function () {
+        it('should allow to create CreateTransition from document', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(createTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Transition from Create transition', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          const documentTransition = createTransition.toDocumentTransition()
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(createTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Batch Transition from Document Transitions', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          const documentTransition = createTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(createTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create state document_transitions from document and convert state transition to document batch', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          const documentTransition = createTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          const st = batchTransition.toStateTransition()
+
+          const deserializedBatch = wasm.BatchTransitionWASM.fromStateTransition(st)
+
+          const deserializedTransitions = deserializedBatch.transitions
+
+          assert.equal(deserializedTransitions.length, 2)
+
+          const deserializedPurchaseTransition = deserializedTransitions[0].toTransition().createTransition
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(createTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+          assert.notEqual(st.__wbg_ptr, 0)
+          assert.notEqual(deserializedBatch.__wbg_ptr, 0)
+          assert.notEqual(deserializedPurchaseTransition.__wbg_ptr, 0)
+        })
+      })
+
+      describe('document Delete transition', function () {
+        it('should allow to create DeleteTransition from document', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const deleteTransition = new wasm.DocumentDeleteTransitionWASM(documentInstance, BigInt(1))
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(deleteTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Transition from Delete transition', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const deleteTransition = new wasm.DocumentDeleteTransitionWASM(documentInstance, BigInt(1))
+
+          const documentTransition = deleteTransition.toDocumentTransition()
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(deleteTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Batch Transition from Document Transitions', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const deleteTransition = new wasm.DocumentDeleteTransitionWASM(documentInstance, BigInt(1))
+
+          const documentTransition = deleteTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(deleteTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create state document_transitions from document and convert state transition to document batch', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const deleteTransition = new wasm.DocumentDeleteTransitionWASM(documentInstance, BigInt(1))
+
+          const documentTransition = deleteTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          const st = batchTransition.toStateTransition()
+
+          const deserializedBatch = wasm.BatchTransitionWASM.fromStateTransition(st)
+
+          const deserializedTransitions = deserializedBatch.transitions
+
+          assert.equal(deserializedTransitions.length, 2)
+
+          const deserializedPurchaseTransition = deserializedTransitions[0].toTransition().deleteTransition
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(deleteTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+          assert.notEqual(st.__wbg_ptr, 0)
+          assert.notEqual(deserializedBatch.__wbg_ptr, 0)
+          assert.notEqual(deserializedPurchaseTransition.__wbg_ptr, 0)
+        })
+      })
+
+      describe('document Replace transition', function () {
+        it('should allow to create ReplaceTransition from document', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const replaceTransition = new wasm.DocumentReplaceTransitionWASM(documentInstance, BigInt(1))
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(replaceTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Transition from Replace transition', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const replaceTransition = new wasm.DocumentReplaceTransitionWASM(documentInstance, BigInt(1))
+
+          const documentTransition = replaceTransition.toDocumentTransition()
+
+          assert.notEqual(replaceTransition.__wbg_ptr, 0)
+          assert.notEqual(replaceTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Batch Transition from Document Transitions', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const replaceTransition = new wasm.DocumentReplaceTransitionWASM(documentInstance, BigInt(1))
+
+          const documentTransition = replaceTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(replaceTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create state document_transitions from document and convert state transition to document batch', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const replaceTransition = new wasm.DocumentReplaceTransitionWASM(documentInstance, BigInt(1))
+
+          const documentTransition = replaceTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          const st = batchTransition.toStateTransition()
+
+          const deserializedBatch = wasm.BatchTransitionWASM.fromStateTransition(st)
+
+          const deserializedTransitions = deserializedBatch.transitions
+
+          assert.equal(deserializedTransitions.length, 2)
+
+          const deserializedPurchaseTransition = deserializedTransitions[0].toTransition().replaceTransition
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(replaceTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+          assert.notEqual(st.__wbg_ptr, 0)
+          assert.notEqual(deserializedBatch.__wbg_ptr, 0)
+          assert.notEqual(deserializedPurchaseTransition.__wbg_ptr, 0)
+        })
+      })
+
+      describe('document Transfer transition', function () {
+        it('should allow to create ReplaceTransition from document', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const transferTransition = new wasm.DocumentTransferTransitionWASM(documentInstance, BigInt(1), documentInstance.ownerId)
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(transferTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Transition from Replace transition', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const transferTransition = new wasm.DocumentTransferTransitionWASM(documentInstance, BigInt(1), documentInstance.ownerId)
+
+          const documentTransition = transferTransition.toDocumentTransition()
+
+          assert.notEqual(transferTransition.__wbg_ptr, 0)
+          assert.notEqual(transferTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Batch Transition from Document Transitions', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const transferTransition = new wasm.DocumentTransferTransitionWASM(documentInstance, BigInt(1), documentInstance.ownerId)
+
+          const documentTransition = transferTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(transferTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create state document_transitions from document and convert state transition to document batch', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const transferTransition = new wasm.DocumentTransferTransitionWASM(documentInstance, BigInt(1), documentInstance.ownerId)
+
+          const documentTransition = transferTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          const st = batchTransition.toStateTransition()
+
+          const deserializedBatch = wasm.BatchTransitionWASM.fromStateTransition(st)
+
+          const deserializedTransitions = deserializedBatch.transitions
+
+          assert.equal(deserializedTransitions.length, 2)
+
+          const deserializedPurchaseTransition = deserializedTransitions[0].toTransition().transferTransition
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(transferTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+          assert.notEqual(st.__wbg_ptr, 0)
+          assert.notEqual(deserializedBatch.__wbg_ptr, 0)
+          assert.notEqual(deserializedPurchaseTransition.__wbg_ptr, 0)
+        })
+      })
+
+      describe('document UpdatePrice transition', function () {
+        it('should allow to create UpdatePriceTransition from document', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const updatePriceTransition = new wasm.DocumentUpdatePriceTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(updatePriceTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Transition from UpdatePrice transition', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const updatePriceTransition = new wasm.DocumentUpdatePriceTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          const documentTransition = updatePriceTransition.toDocumentTransition()
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(updatePriceTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Batch Transition from Document Transitions', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const updatePriceTransition = new wasm.DocumentUpdatePriceTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          const documentTransition = updatePriceTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(updatePriceTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create state document_transitions from document and convert state transition to document batch', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const updatePriceTransition = new wasm.DocumentUpdatePriceTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          const documentTransition = updatePriceTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          const st = batchTransition.toStateTransition()
+
+          const deserializedBatch = wasm.BatchTransitionWASM.fromStateTransition(st)
+
+          const deserializedTransitions = deserializedBatch.transitions
+
+          assert.equal(deserializedTransitions.length, 2)
+
+          const deserializedPurchaseTransition = deserializedTransitions[0].toTransition().updatePriceTransition
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(updatePriceTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+          assert.notEqual(st.__wbg_ptr, 0)
+          assert.notEqual(deserializedBatch.__wbg_ptr, 0)
+          assert.notEqual(deserializedPurchaseTransition.__wbg_ptr, 0)
+        })
+      })
+
+      describe('document Purchase transition', function () {
+        it('should allow to create PurchaseTransition from document', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const purchaseTransition = new wasm.DocumentPurchaseTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(purchaseTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Transition from PurchaseTransition transition', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const purchaseTransition = new wasm.DocumentPurchaseTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          const documentTransition = purchaseTransition.toDocumentTransition()
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(purchaseTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create Document Batch Transition from Document Transitions', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const purchaseTransition = new wasm.DocumentPurchaseTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          const documentTransition = purchaseTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(purchaseTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+        })
+
+        it('should allow to create state document_transitions from document and convert state transition to document batch', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const purchaseTransition = new wasm.DocumentPurchaseTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          const documentTransition = purchaseTransition.toDocumentTransition()
+
+          const batchTransition = wasm.BatchTransitionWASM.fromV0Transitions([documentTransition, documentTransition], documentInstance.ownerId, 1, 1)
+
+          const st = batchTransition.toStateTransition()
+
+          const deserializedBatch = wasm.BatchTransitionWASM.fromStateTransition(st)
+
+          const deserializedTransitions = deserializedBatch.transitions
+
+          assert.equal(deserializedTransitions.length, 2)
+
+          const deserializedPurchaseTransition = deserializedTransitions[0].toTransition().purchaseTransition
+
+          assert.notEqual(documentInstance.__wbg_ptr, 0)
+          assert.notEqual(purchaseTransition.__wbg_ptr, 0)
+          assert.notEqual(documentTransition.__wbg_ptr, 0)
+          assert.notEqual(batchTransition.__wbg_ptr, 0)
+          assert.notEqual(st.__wbg_ptr, 0)
+          assert.notEqual(deserializedBatch.__wbg_ptr, 0)
+          assert.notEqual(deserializedPurchaseTransition.__wbg_ptr, 0)
+        })
+      })
+    })
+    describe('getters', function () {
+      describe('document Create transition', function () {
+        it('get data', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          assert.deepEqual(createTransition.data, document)
+        })
+
+        it('get base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          assert.equal(createTransition.base.constructor.name, 'DocumentBaseTransitionWASM')
+        })
+
+        it('get entropy', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          assert.deepEqual(createTransition.entropy, documentInstance.entropy)
+        })
+
+        it('get prefunded voting balance', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          assert.equal(createTransition.prefundedVotingBalance, undefined)
+        })
+      })
+
+      describe('document Delete transition', function () {
+        it('get base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const deleteTransition = new wasm.DocumentDeleteTransitionWASM(documentInstance, BigInt(1))
+
+          assert.equal(deleteTransition.base.constructor.name, 'DocumentBaseTransitionWASM')
+        })
+      })
+
+      describe('document Replace transition', function () {
+        it('get data', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const replaceTransition = new wasm.DocumentReplaceTransitionWASM(documentInstance, BigInt(1))
+
+          assert.deepEqual(replaceTransition.data, document)
+        })
+
+        it('get base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const replaceTransition = new wasm.DocumentReplaceTransitionWASM(documentInstance, BigInt(1))
+
+          assert.equal(replaceTransition.base.constructor.name, 'DocumentBaseTransitionWASM')
+        })
+
+        it('get revision', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const replaceTransition = new wasm.DocumentReplaceTransitionWASM(documentInstance, BigInt(1))
+
+          assert.equal(replaceTransition.revision, BigInt(2))
+        })
+      })
+
+      describe('document Transfer transition', function () {
+        it('get base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const transferTransition = new wasm.DocumentTransferTransitionWASM(documentInstance, BigInt(1), documentInstance.ownerId)
+
+          assert.equal(transferTransition.base.constructor.name, 'DocumentBaseTransitionWASM')
+        })
+
+        it('get recipient', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const transferTransition = new wasm.DocumentTransferTransitionWASM(documentInstance, BigInt(1), documentInstance.ownerId)
+
+          assert.deepEqual(transferTransition.recipientId.base58(), documentInstance.ownerId.base58())
+        })
+      })
+
+      describe('document Update Price transition', function () {
+        it('get base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const updatePriceTransition = new wasm.DocumentUpdatePriceTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          assert.equal(updatePriceTransition.base.constructor.name, 'DocumentBaseTransitionWASM')
+        })
+
+        it('get price', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const updatePriceTransition = new wasm.DocumentUpdatePriceTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          assert.deepEqual(updatePriceTransition.price, BigInt(100))
+        })
+      })
+
+      describe('document Purchase transition', function () {
+        it('get base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const purchaseTransition = new wasm.DocumentPurchaseTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          assert.equal(purchaseTransition.base.constructor.name, 'DocumentBaseTransitionWASM')
+        })
+
+        it('get price', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const purchaseTransition = new wasm.DocumentPurchaseTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          assert.deepEqual(purchaseTransition.price, BigInt(100))
+        })
+      })
+    })
+
+    describe('setters', function () {
+      describe('document Create transition', function () {
+        it('set data', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          const newData = { message: 'bebra' }
+
+          createTransition.data = newData
+
+          assert.deepEqual(createTransition.data, newData)
+        })
+
+        it('set base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          const newBase = new wasm.DocumentBaseTransitionWASM(
+            documentInstance.id,
+            BigInt(12350),
+            'bbbbb',
+            dataContractId
+          )
+
+          createTransition.base = newBase
+
+          assert.equal(createTransition.base.identityContractNonce, newBase.identityContractNonce)
+          assert.notEqual(newBase.__wbg_ptr, 0)
+        })
+
+        it('set entropy', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          const newEntropy = new Uint8Array(32)
+
+          createTransition.entropy = newEntropy
+
+          assert.deepEqual(createTransition.entropy, newEntropy)
+        })
+
+        it('set prefunded voting balance', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const createTransition = new wasm.DocumentCreateTransitionWASM(documentInstance, BigInt(1))
+
+          const newPrefundedVotingBalance = new wasm.PrefundedVotingBalanceWASM('note', BigInt(9999))
+
+          createTransition.prefundedVotingBalance = newPrefundedVotingBalance
+
+          assert.equal(createTransition.prefundedVotingBalance.indexName, newPrefundedVotingBalance.indexName)
+          assert.equal(createTransition.prefundedVotingBalance.credits, newPrefundedVotingBalance.credits)
+        })
+      })
+
+      describe('document Delete transition', function () {
+        it('set base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const deleteTransition = new wasm.DocumentDeleteTransitionWASM(documentInstance, BigInt(1))
+
+          const newBase = new wasm.DocumentBaseTransitionWASM(
+            documentInstance.id,
+            BigInt(12350),
+            'bbbbb',
+            dataContractId
+          )
+
+          deleteTransition.base = newBase
+
+          assert.equal(deleteTransition.base.identityContractNonce, newBase.identityContractNonce)
+          assert.notEqual(newBase.__wbg_ptr, 0)
+        })
+      })
+
+      describe('document Replace transition', function () {
+        it('set data', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const replaceTransition = new wasm.DocumentReplaceTransitionWASM(documentInstance, BigInt(1))
+
+          const newData = { message: 'bebra' }
+
+          replaceTransition.data = newData
+
+          assert.deepEqual(replaceTransition.data, newData)
+        })
+
+        it('set base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const replaceTransition = new wasm.DocumentReplaceTransitionWASM(documentInstance, BigInt(1))
+
+          const newBase = new wasm.DocumentBaseTransitionWASM(
+            documentInstance.id,
+            BigInt(12350),
+            'bbbbb',
+            dataContractId
+          )
+
+          replaceTransition.base = newBase
+
+          assert.equal(replaceTransition.base.identityContractNonce, newBase.identityContractNonce)
+          assert.notEqual(newBase.__wbg_ptr, 0)
+        })
+
+        it('set revision', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const replaceTransition = new wasm.DocumentReplaceTransitionWASM(documentInstance, BigInt(1))
+
+          replaceTransition.revision = BigInt(11)
+
+          assert.equal(replaceTransition.revision, BigInt(11))
+        })
+      })
+
+      describe('document Transfer transition', function () {
+        it('set base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const transferTransition = new wasm.DocumentTransferTransitionWASM(documentInstance, BigInt(1), documentInstance.ownerId)
+
+          const newBase = new wasm.DocumentBaseTransitionWASM(
+            documentInstance.id,
+            BigInt(12350),
+            'bbbbb',
+            dataContractId
+          )
+
+          transferTransition.base = newBase
+
+          assert.equal(transferTransition.base.identityContractNonce, newBase.identityContractNonce)
+          assert.notEqual(newBase.__wbg_ptr, 0)
+        })
+
+        it('set recipient', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const transferTransition = new wasm.DocumentTransferTransitionWASM(documentInstance, BigInt(1), documentInstance.ownerId)
+
+          const newRecipient = new Uint8Array(32)
+
+          transferTransition.recipientId = newRecipient
+
+          assert.deepEqual(transferTransition.recipientId.bytes(), newRecipient)
+        })
+      })
+
+      describe('document Update Price transition', function () {
+        it('set base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const updatePriceTransition = new wasm.DocumentUpdatePriceTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          const newBase = new wasm.DocumentBaseTransitionWASM(
+            documentInstance.id,
+            BigInt(12350),
+            'bbbbb',
+            dataContractId
+          )
+
+          updatePriceTransition.base = newBase
+
+          assert.equal(updatePriceTransition.base.identityContractNonce, newBase.identityContractNonce)
+          assert.notEqual(newBase.__wbg_ptr, 0)
+        })
+
+        it('set price', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const updatePriceTransition = new wasm.DocumentUpdatePriceTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          updatePriceTransition.price = BigInt(1111)
+
+          assert.deepEqual(updatePriceTransition.price, BigInt(1111))
+        })
+      })
+
+      describe('document Purchase transition', function () {
+        it('set base', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const purchaseTransition = new wasm.DocumentPurchaseTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          const newBase = new wasm.DocumentBaseTransitionWASM(
+            documentInstance.id,
+            BigInt(12350),
+            'bbbbb',
+            dataContractId
+          )
+
+          purchaseTransition.base = newBase
+
+          assert.equal(purchaseTransition.base.identityContractNonce, newBase.identityContractNonce)
+          assert.notEqual(newBase.__wbg_ptr, 0)
+        })
+
+        it('set price', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const purchaseTransition = new wasm.DocumentPurchaseTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          purchaseTransition.price = BigInt(1111)
+
+          assert.deepEqual(purchaseTransition.price, BigInt(1111))
+        })
+
+        it('set revision', () => {
+          const documentInstance = new wasm.DocumentWASM(document, documentTypeName, revision, dataContractId, ownerId, id)
+          const purchaseTransition = new wasm.DocumentPurchaseTransitionWASM(documentInstance, BigInt(1), BigInt(100))
+
+          purchaseTransition.revision = BigInt(1111)
+
+          assert.deepEqual(purchaseTransition.revision, BigInt(1111))
+        })
+      })
+    })
+  })
+})

--- a/tests/Identifier.spec.cjs
+++ b/tests/Identifier.spec.cjs
@@ -1,14 +1,11 @@
 const assert = require('assert')
 const { describe, it, before } = require('mocha')
-const { default: initWASM } = require('..')
+const { default: wasm } = require('..')
 
 let identifierBytes
-let wasm
 
 describe('Identifier', function () {
   before(async function () {
-    wasm = await initWASM()
-
     identifierBytes = Uint8Array.from([9, 40, 40, 237, 192, 129, 211, 186, 26, 84, 240, 67, 37, 155, 148, 19, 104, 242, 199, 24, 136, 27, 6, 169, 211, 71, 136, 59, 33, 191, 227, 19])
   })
 

--- a/tests/Identifier.spec.cjs
+++ b/tests/Identifier.spec.cjs
@@ -1,11 +1,14 @@
 const assert = require('assert')
 const { describe, it, before } = require('mocha')
-const { default: wasm } = require('..')
+const { default: initWASM } = require('..')
 
 let identifierBytes
+let wasm
 
 describe('Identifier', function () {
   before(async function () {
+    wasm = await initWASM()
+
     identifierBytes = Uint8Array.from([9, 40, 40, 237, 192, 129, 211, 186, 26, 84, 240, 67, 37, 155, 148, 19, 104, 242, 199, 24, 136, 27, 6, 169, 211, 71, 136, 59, 33, 191, 227, 19])
   })
 

--- a/tests/Identifier.spec.cjs
+++ b/tests/Identifier.spec.cjs
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const { describe, it, before } = require('mocha')
-const { default: wasm } = require('..')
+const { default: wasm } = require('pshenmic-dpp')
 
 let identifierBytes
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,9 @@
       "dom"
     ]
   },
-  "include": ["dist/**/*.ts"],
+  "include": [
+    "**/*.ts"
+  ],
   "exclude": [
     "node_modules",
     "lib"

--- a/utils/convertBinary.mjs
+++ b/utils/convertBinary.mjs
@@ -1,34 +1,37 @@
-import fs from 'fs'
-import { encode } from './base122.mjs'
+import fs from 'fs';
+import {encode} from './base122.mjs';
 import zlib from "zlib";
 
-process.argv.forEach(function (val, index) {
-  if (val.includes('.wasm')) {
-    const binaryData = fs.readFileSync(val)
+const inputFile = process.argv[2];
+const outputFile = process.argv[3];
 
-    const bufferData = Buffer.from(binaryData)
+if (!inputFile || !outputFile) {
+  console.error("Usage: node <script.js> <input_file> <output_file>");
+  process.exit(1);
+}
 
-    const compressedChunks = [];
+const binaryData = fs.readFileSync(inputFile);
+const bufferData = Buffer.from(binaryData);
+const compressedChunks = [];
 
-    const gzip = zlib.createGzip({
-      level: 9,
-      memLevel: 9
-    })
+const gzip = zlib.createGzip({
+  level: zlib.constants.Z_BEST_COMPRESSION,
+  memLevel: zlib.constants.Z_MAX_MEMLEVEL,
+});
 
-    gzip.on('data', data => {
-      compressedChunks.push(...data)
-    })
+gzip.on('data', data => {
+  compressedChunks.push(...data);
+});
 
-    gzip.on('end', () => {
-      const encodedData = Buffer.from(encode(compressedChunks)).toString('utf-8')
+gzip.on('end', () => {
+  const encodedData = Buffer.from(encode(compressedChunks)).toString('utf-8');
+  const outputContent = `export default "${encodedData}"`;
 
-      console.log(`export default "${encodedData}"`)
+  fs.writeFileSync(outputFile, outputContent);
 
-      process.exit(0)
-    })
+  console.log(`Successfully converted ${inputFile} to ${outputFile}`);
+  process.exit(0);
+});
 
-    gzip.write(bufferData)
-
-    gzip.end()
-  }
-})
+gzip.write(bufferData);
+gzip.end();

--- a/utils/convertBinary.mjs
+++ b/utils/convertBinary.mjs
@@ -1,14 +1,34 @@
 import fs from 'fs'
 import { encode } from './base122.mjs'
+import zlib from "zlib";
 
 process.argv.forEach(function (val, index) {
   if (val.includes('.wasm')) {
     const binaryData = fs.readFileSync(val)
 
-    const encodedData = Buffer.from(encode(binaryData)).toString('utf-8')
+    const bufferData = Buffer.from(binaryData)
 
-    console.log(`export default "${encodedData}"`)
+    const compressedChunks = [];
 
-    process.exit(0)
+    const gzip = zlib.createGzip({
+      level: 9,
+      memLevel: 9
+    })
+
+    gzip.on('data', data => {
+      compressedChunks.push(...data)
+    })
+
+    gzip.on('end', () => {
+      const encodedData = Buffer.from(encode(compressedChunks)).toString('utf-8')
+
+      console.log(`export default "${encodedData}"`)
+
+      process.exit(0)
+    })
+
+    gzip.write(bufferData)
+
+    gzip.end()
   }
 })

--- a/utils/generate-docs.ts
+++ b/utils/generate-docs.ts
@@ -1,5 +1,4 @@
-import {Project, SyntaxKind, JSDocTagInfo, TypeFormatFlags} from "ts-morph";
-import * as path from "path";
+import {Project, TypeFormatFlags} from "ts-morph";
 
 const project = new Project({
     tsConfigFilePath: "tsconfig.json",


### PR DESCRIPTION
# Issue
We need to reduce size 

# Things done
- Updated build scripts
- Changed module type in `package.json` to `module `
- Implemented new typings
- Implemented new import alghoritms (sync+async)
- Updated README.md
- Added tiny tests for async import
- `ts-node` replaced with `tsx`
- Added `rollup` package
- NEW SIZE: 1.4 or 2.2 mb
- Bump
- JS layer code optimization and updated convertation for files, which now includes gzip compression