### PR TITLE
Fix memory leaks on verify contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.1.0-dev.6"
+version = "1.1.0-dev.7"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "dpns-contract"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "bincode",
  "byteorder",
@@ -774,7 +774,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "feature-flags-contract"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1537,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1588,7 +1588,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1917,7 +1917,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform-serialization"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "bincode",
  "platform-version",
@@ -1926,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1937,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "base64",
  "bincode",
@@ -1956,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "bincode",
  "grovedb-version",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3008,7 +3008,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3284,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3577,7 +3577,7 @@ checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 [[package]]
 name = "withdrawals-contract"
 version = "2.0.1"
-source = "git+https://github.com/owl352/platform?branch=v2.0.1#f6d7390361861f5a62b7cb413310b5ec42c26387"
+source = "git+https://github.com/owl352/platform?rev=4aa29b8#4aa29b808a1a825d37043e118a26a892cfb8ad0a"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.1.0-dev.6"
+version = "1.1.0-dev.7"
 edition = "2024"
 rust-version = "1.85"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [workspace.dependencies]
-dpp = { git = "https://github.com/owl352/platform", branch = "v2.0.1", default-features = false }
-drive = { git = "https://github.com/owl352/platform", branch = "v2.0.1", default-features = false }
+dpp = { git = "https://github.com/owl352/platform", rev = "4aa29b8", default-features = false }
+drive = { git = "https://github.com/owl352/platform", rev = "4aa29b8", default-features = false }
 wasm-bindgen = { version = "=0.2.101", default-features = false, features = ["std"]}
 js-sys = { version = "0.3.78" }
 serde-wasm-bindgen = { git = "https://github.com/QuantumExplorer/serde-wasm-bindgen", branch = "feat/not_human_readable" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.1.0-dev.6",
+  "version": "1.1.0-dev.7",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "type": "module",

--- a/packages/asset_lock_proof/src/chain/mod.rs
+++ b/packages/asset_lock_proof/src/chain/mod.rs
@@ -53,10 +53,10 @@ impl ChainAssetLockProofWASM {
 
     #[wasm_bindgen(js_name = "fromRawObject")]
     pub fn from_raw_value(
-        raw_asset_lock_proof: JsValue,
+        raw_asset_lock_proof: &JsValue,
     ) -> Result<ChainAssetLockProofWASM, JsValue> {
         let parameters: ChainAssetLockProofParams =
-            serde_wasm_bindgen::from_value(raw_asset_lock_proof)
+            serde_wasm_bindgen::from_value(raw_asset_lock_proof.clone())
                 .map_err(|err| JsError::from(err))?;
 
         let out_point: [u8; 36] = parameters

--- a/packages/asset_lock_proof/src/instant/mod.rs
+++ b/packages/asset_lock_proof/src/instant/mod.rs
@@ -68,8 +68,8 @@ impl InstantAssetLockProofWASM {
 
     #[wasm_bindgen(js_name = "fromObject")]
     pub fn from_object(value: &JsValue) -> Result<InstantAssetLockProofWASM, JsValue> {
-        let parameters: InstantAssetLockProofRAW =
-            serde_wasm_bindgen::from_value(value.clone()).map_err(|err| JsValue::from(err.to_string()))?;
+        let parameters: InstantAssetLockProofRAW = serde_wasm_bindgen::from_value(value.clone())
+            .map_err(|err| JsValue::from(err.to_string()))?;
 
         InstantAssetLockProofWASM::new(
             parameters.instant_lock,

--- a/packages/asset_lock_proof/src/instant/mod.rs
+++ b/packages/asset_lock_proof/src/instant/mod.rs
@@ -67,9 +67,9 @@ impl InstantAssetLockProofWASM {
     }
 
     #[wasm_bindgen(js_name = "fromObject")]
-    pub fn from_object(value: JsValue) -> Result<InstantAssetLockProofWASM, JsValue> {
+    pub fn from_object(value: &JsValue) -> Result<InstantAssetLockProofWASM, JsValue> {
         let parameters: InstantAssetLockProofRAW =
-            serde_wasm_bindgen::from_value(value).map_err(|err| JsValue::from(err.to_string()))?;
+            serde_wasm_bindgen::from_value(value.clone()).map_err(|err| JsValue::from(err.to_string()))?;
 
         InstantAssetLockProofWASM::new(
             parameters.instant_lock,

--- a/packages/asset_lock_proof/src/tx_out/mod.rs
+++ b/packages/asset_lock_proof/src/tx_out/mod.rs
@@ -36,7 +36,9 @@ impl TxOutWASM {
         let tx_out: Result<TxOut, JsValue> = match script_pubkey.is_array() {
             true => Ok(TxOut {
                 value,
-                script_pubkey: ScriptBuf::from_bytes(Uint8Array::from(script_pubkey.clone()).to_vec()),
+                script_pubkey: ScriptBuf::from_bytes(
+                    Uint8Array::from(script_pubkey.clone()).to_vec(),
+                ),
             }),
             false => match script_pubkey.is_string() {
                 true => {

--- a/packages/asset_lock_proof/src/tx_out/mod.rs
+++ b/packages/asset_lock_proof/src/tx_out/mod.rs
@@ -32,11 +32,11 @@ impl TxOutWASM {
     }
 
     #[wasm_bindgen(constructor)]
-    pub fn new(value: u64, script_pubkey: JsValue) -> Result<TxOutWASM, JsValue> {
+    pub fn new(value: u64, script_pubkey: &JsValue) -> Result<TxOutWASM, JsValue> {
         let tx_out: Result<TxOut, JsValue> = match script_pubkey.is_array() {
             true => Ok(TxOut {
                 value,
-                script_pubkey: ScriptBuf::from_bytes(Uint8Array::from(script_pubkey).to_vec()),
+                script_pubkey: ScriptBuf::from_bytes(Uint8Array::from(script_pubkey.clone()).to_vec()),
             }),
             false => match script_pubkey.is_string() {
                 true => {

--- a/packages/batch/src/document_transitions/create/mod.rs
+++ b/packages/batch/src/document_transitions/create/mod.rs
@@ -99,7 +99,7 @@ impl DocumentCreateTransitionWASM {
     }
 
     #[wasm_bindgen(setter = "data")]
-    pub fn set_data(&mut self, js_data: JsValue) -> Result<(), JsValue> {
+    pub fn set_data(&mut self, js_data: &JsValue) -> Result<(), JsValue> {
         let data = js_data.with_serde_to_platform_value_map()?;
 
         Ok(self.0.set_data(data))

--- a/packages/batch/src/document_transitions/replace/mod.rs
+++ b/packages/batch/src/document_transitions/replace/mod.rs
@@ -84,7 +84,7 @@ impl DocumentReplaceTransitionWASM {
     }
 
     #[wasm_bindgen(setter = "data")]
-    pub fn set_data(&mut self, js_data: JsValue) -> Result<(), JsValue> {
+    pub fn set_data(&mut self, js_data: &JsValue) -> Result<(), JsValue> {
         let data = js_data.with_serde_to_platform_value_map()?;
 
         Ok(self.0.set_data(data))

--- a/packages/data_contract/src/lib.rs
+++ b/packages/data_contract/src/lib.rs
@@ -88,11 +88,11 @@ impl DataContractWASM {
     pub fn from_js_values(
         js_owner_id: &JsValue,
         identity_nonce: IdentityNonce,
-        js_schema: JsValue,
+        js_schema: &JsValue,
         js_definitions: Option<js_sys::Object>,
         js_tokens: &JsValue,
         full_validation: bool,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DataContractWASM, JsValue> {
         let serializer = serde_wasm_bindgen::Serializer::json_compatible();
 
@@ -100,7 +100,7 @@ impl DataContractWASM {
 
         let owner_id_value = Value::from(owner_id.get_base58());
 
-        let schema: Value = serde_wasm_bindgen::from_value(js_schema)?;
+        let schema: Value = serde_wasm_bindgen::from_value(js_schema.clone())?;
 
         let tokens: BTreeMap<TokenContractPosition, TokenConfiguration> =
             match js_tokens.is_undefined() {
@@ -110,7 +110,7 @@ impl DataContractWASM {
 
         let platform_version: PlatformVersion = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default().into(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?.into(),
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?.into(),
         };
 
         let data_contract_structure_version_value = Value::from(
@@ -188,13 +188,13 @@ impl DataContractWASM {
 
     #[wasm_bindgen(js_name = "fromValue")]
     pub fn from_value(
-        js_value: JsValue,
+        js_value: &JsValue,
         full_validation: bool,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DataContractWASM, JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let value = js_value.with_serde_to_platform_value()?;
@@ -209,11 +209,11 @@ impl DataContractWASM {
     pub fn from_bytes(
         bytes: Vec<u8>,
         full_validation: bool,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DataContractWASM, JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let rs_data_contract = DataContract::versioned_deserialize(
@@ -230,7 +230,7 @@ impl DataContractWASM {
     pub fn from_hex(
         hex: String,
         full_validation: bool,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DataContractWASM, JsValue> {
         DataContractWASM::from_bytes(
             decode(hex.as_str(), Hex).map_err(JsError::from)?,
@@ -243,7 +243,7 @@ impl DataContractWASM {
     pub fn from_base64(
         base64: String,
         full_validation: bool,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DataContractWASM, JsValue> {
         DataContractWASM::from_bytes(
             decode(base64.as_str(), Base64).map_err(JsError::from)?,
@@ -253,10 +253,10 @@ impl DataContractWASM {
     }
 
     #[wasm_bindgen(js_name = "bytes")]
-    pub fn to_bytes(&self, js_platform_version: JsValue) -> Result<Vec<u8>, JsValue> {
+    pub fn to_bytes(&self, js_platform_version: &JsValue) -> Result<Vec<u8>, JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let rs_data_contract: DataContract = self.0.clone();
@@ -267,12 +267,12 @@ impl DataContractWASM {
     }
 
     #[wasm_bindgen(js_name = "hex")]
-    pub fn to_hex(&self, js_platform_version: JsValue) -> Result<String, JsValue> {
+    pub fn to_hex(&self, js_platform_version: &JsValue) -> Result<String, JsValue> {
         Ok(encode(self.to_bytes(js_platform_version)?.as_slice(), Hex))
     }
 
     #[wasm_bindgen(js_name = "base64")]
-    pub fn to_base64(&self, js_platform_version: JsValue) -> Result<String, JsValue> {
+    pub fn to_base64(&self, js_platform_version: &JsValue) -> Result<String, JsValue> {
         Ok(encode(
             self.to_bytes(js_platform_version)?.as_slice(),
             Base64,
@@ -280,10 +280,10 @@ impl DataContractWASM {
     }
 
     #[wasm_bindgen(js_name = "toValue")]
-    pub fn to_value(&self, js_platform_version: JsValue) -> Result<JsValue, JsValue> {
+    pub fn to_value(&self, js_platform_version: &JsValue) -> Result<JsValue, JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let serializer = serde_wasm_bindgen::Serializer::json_compatible();
@@ -381,15 +381,15 @@ impl DataContractWASM {
     #[wasm_bindgen(js_name = "setConfig")]
     pub fn set_config(
         &mut self,
-        js_config: JsValue,
-        js_platform_version: JsValue,
+        js_config: &JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<(), JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
-        let config_value: Value = serde_wasm_bindgen::from_value(js_config)?;
+        let config_value: Value = serde_wasm_bindgen::from_value(js_config.clone())?;
 
         let config = DataContractConfig::from_value(config_value, &platform_version.into())
             .with_js_error()?;
@@ -402,14 +402,14 @@ impl DataContractWASM {
     #[wasm_bindgen(js_name = "setSchemas")]
     pub fn set_schemas(
         &mut self,
-        js_schema: JsValue,
+        js_schema: &JsValue,
         js_definitions: Option<js_sys::Object>,
         full_validation: bool,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<(), JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let schema = js_schema.with_serde_to_platform_value_map()?;
@@ -472,10 +472,10 @@ impl DataContractWASM {
     }
 
     #[wasm_bindgen(js_name = "toJson")]
-    pub fn to_json(&self, js_platform_version: JsValue) -> Result<JsValue, JsValue> {
+    pub fn to_json(&self, js_platform_version: &JsValue) -> Result<JsValue, JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let json = self.0.to_json(&platform_version.into()).with_js_error()?;

--- a/packages/data_contract_transitions/src/create/mod.rs
+++ b/packages/data_contract_transitions/src/create/mod.rs
@@ -39,13 +39,13 @@ impl DataContractCreateTransitionWASM {
     pub fn new(
         data_contract: &DataContractWASM,
         identity_nonce: IdentityNonce,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DataContractCreateTransitionWASM, JsValue> {
         let rs_data_contract: DataContract = data_contract.clone().into();
 
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let rs_data_contract_in_serialized: Result<
@@ -135,11 +135,11 @@ impl DataContractCreateTransitionWASM {
     pub fn set_data_contract(
         &mut self,
         data_contract: &DataContractWASM,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<(), JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let data_contract_serialization_format =
@@ -162,12 +162,12 @@ impl DataContractCreateTransitionWASM {
     #[wasm_bindgen(js_name = "getDataContract")]
     pub fn get_data_contract(
         &self,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
         full_validation: Option<bool>,
     ) -> Result<DataContractWASM, JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let rs_data_contract_serialization_format = self.0.data_contract();

--- a/packages/data_contract_transitions/src/update/mod.rs
+++ b/packages/data_contract_transitions/src/update/mod.rs
@@ -34,11 +34,11 @@ impl DataContractUpdateTransitionWASM {
     pub fn new(
         data_contract: &DataContractWASM,
         identity_nonce: IdentityNonce,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DataContractUpdateTransitionWASM, JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let rs_data_contract_update_transition =
@@ -118,11 +118,11 @@ impl DataContractUpdateTransitionWASM {
     pub fn set_data_contract(
         &mut self,
         data_contract: &DataContractWASM,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<(), JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let data_contract_serialization_format =
@@ -146,11 +146,11 @@ impl DataContractUpdateTransitionWASM {
     pub fn get_data_contract(
         &self,
         full_validation: Option<bool>,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DataContractWASM, JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let data_contract_serialization_format = self.0.data_contract();

--- a/packages/document/src/methods/mod.rs
+++ b/packages/document/src/methods/mod.rs
@@ -34,7 +34,7 @@ impl DocumentWASM {
 
     #[wasm_bindgen(constructor)]
     pub fn new(
-        js_raw_document: JsValue,
+        js_raw_document: &JsValue,
         js_document_type_name: &str,
         js_revision: u64,
         js_data_contract_id: &JsValue,
@@ -183,7 +183,7 @@ impl DocumentWASM {
     }
 
     #[wasm_bindgen(setter=entropy)]
-    pub fn set_entropy(&mut self, entropy: JsValue) -> Result<(), JsValue> {
+    pub fn set_entropy(&mut self, entropy: &JsValue) -> Result<(), JsValue> {
         match entropy.is_undefined() {
             false => {
                 let value = entropy.with_serde_to_platform_value()?;
@@ -217,7 +217,7 @@ impl DocumentWASM {
     }
 
     #[wasm_bindgen(setter=properties)]
-    pub fn set_properties(&mut self, properties: JsValue) -> Result<(), JsValue> {
+    pub fn set_properties(&mut self, properties: &JsValue) -> Result<(), JsValue> {
         self.properties = properties.with_serde_to_platform_value_map()?;
 
         Ok(())
@@ -285,11 +285,11 @@ impl DocumentWASM {
     pub fn to_bytes(
         &self,
         data_contract: &DataContractWASM,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<Vec<u8>, JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let rs_document: Document = Document::from(self.clone());
@@ -311,7 +311,7 @@ impl DocumentWASM {
     pub fn to_hex(
         &self,
         data_contract: &DataContractWASM,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<String, JsValue> {
         Ok(encode(
             self.to_bytes(data_contract, js_platform_version)?
@@ -324,7 +324,7 @@ impl DocumentWASM {
     pub fn to_base64(
         &self,
         data_contract: &DataContractWASM,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<String, JsValue> {
         Ok(encode(
             self.to_bytes(data_contract, js_platform_version)?
@@ -338,11 +338,11 @@ impl DocumentWASM {
         bytes: Vec<u8>,
         data_contract: &DataContractWASM,
         type_name: String,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DocumentWASM, JsValue> {
         let platform_version = match js_platform_version.is_undefined() {
             true => PlatformVersionWASM::default(),
-            false => PlatformVersionWASM::try_from(js_platform_version)?,
+            false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
         };
 
         let document_type_ref = match data_contract.get_document_type_ref_by_name(type_name.clone())
@@ -371,7 +371,7 @@ impl DocumentWASM {
         hex: String,
         data_contract: &DataContractWASM,
         type_name: String,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DocumentWASM, JsValue> {
         DocumentWASM::from_bytes(
             decode(hex.as_str(), Hex).map_err(JsError::from)?,
@@ -386,7 +386,7 @@ impl DocumentWASM {
         base64: String,
         data_contract: &DataContractWASM,
         type_name: String,
-        js_platform_version: JsValue,
+        js_platform_version: &JsValue,
     ) -> Result<DocumentWASM, JsValue> {
         DocumentWASM::from_bytes(
             decode(base64.as_str(), Base64).map_err(JsError::from)?,

--- a/packages/identity_public_key/src/lib.rs
+++ b/packages/identity_public_key/src/lib.rs
@@ -51,17 +51,17 @@ impl IdentityPublicKeyWASM {
     #[wasm_bindgen(constructor)]
     pub fn new(
         id: u32,
-        js_purpose: JsValue,
-        js_security_level: JsValue,
-        js_key_type: JsValue,
+        js_purpose: &JsValue,
+        js_security_level: &JsValue,
+        js_key_type: &JsValue,
         read_only: bool,
         binary_data: &str,
         disabled_at: Option<TimestampMillis>,
         js_contract_bounds: &JsValue,
     ) -> Result<Self, JsValue> {
-        let purpose = PurposeWASM::try_from(js_purpose)?;
-        let security_level = SecurityLevelWASM::try_from(js_security_level)?;
-        let key_type = KeyTypeWASM::try_from(js_key_type)?;
+        let purpose = PurposeWASM::try_from(js_purpose.clone())?;
+        let security_level = SecurityLevelWASM::try_from(js_security_level.clone())?;
+        let key_type = KeyTypeWASM::try_from(js_key_type.clone())?;
         let contract_bounds: Option<ContractBounds> =
             match js_contract_bounds.is_undefined() | js_contract_bounds.is_null() {
                 true => None,
@@ -95,13 +95,13 @@ impl IdentityPublicKeyWASM {
     pub fn validate_private_key(
         &self,
         js_private_key_bytes: Vec<u8>,
-        js_network: JsValue,
+        js_network: &JsValue,
     ) -> Result<bool, JsValue> {
         let mut private_key_bytes = [0u8; 32];
         let len = js_private_key_bytes.len().min(32);
         private_key_bytes[..len].copy_from_slice(&js_private_key_bytes[..len]);
 
-        let network = Network::from(NetworkWASM::try_from(js_network)?);
+        let network = Network::from(NetworkWASM::try_from(js_network.clone())?);
 
         self.0
             .validate_private_key_bytes(&private_key_bytes, network)
@@ -172,40 +172,38 @@ impl IdentityPublicKeyWASM {
     }
 
     #[wasm_bindgen(setter = purpose)]
-    pub fn set_purpose(&mut self, purpose: JsValue) -> Result<(), JsValue> {
+    pub fn set_purpose(&mut self, purpose: &JsValue) -> Result<(), JsValue> {
         Ok(self
             .0
-            .set_purpose(Purpose::from(PurposeWASM::try_from(purpose)?)))
+            .set_purpose(Purpose::from(PurposeWASM::try_from(purpose.clone())?)))
     }
 
     #[wasm_bindgen(setter = purposeNumber)]
-    pub fn set_purpose_number(&mut self, purpose: JsValue) -> Result<(), JsValue> {
+    pub fn set_purpose_number(&mut self, purpose: &JsValue) -> Result<(), JsValue> {
         self.set_purpose(purpose)
     }
 
     #[wasm_bindgen(setter = securityLevel)]
-    pub fn set_security_level(&mut self, security_level: JsValue) -> Result<(), JsValue> {
+    pub fn set_security_level(&mut self, security_level: &JsValue) -> Result<(), JsValue> {
         Ok(self
             .0
-            .set_security_level(SecurityLevel::from(SecurityLevelWASM::try_from(
-                security_level,
-            )?)))
+            .set_security_level(SecurityLevel::from(SecurityLevelWASM::try_from(security_level.clone())?)))
     }
 
     #[wasm_bindgen(setter = securityLevelNumber)]
-    pub fn set_security_level_number(&mut self, security_level: JsValue) -> Result<(), JsValue> {
+    pub fn set_security_level_number(&mut self, security_level: &JsValue) -> Result<(), JsValue> {
         self.set_security_level(security_level)
     }
 
     #[wasm_bindgen(setter = keyType)]
-    pub fn set_key_type(&mut self, key_type: JsValue) -> Result<(), JsValue> {
+    pub fn set_key_type(&mut self, key_type: &JsValue) -> Result<(), JsValue> {
         Ok(self
             .0
-            .set_key_type(KeyType::from(KeyTypeWASM::try_from(key_type)?)))
+            .set_key_type(KeyType::from(KeyTypeWASM::try_from(key_type.clone())?)))
     }
 
     #[wasm_bindgen(setter = keyTypeNumber)]
-    pub fn set_key_type_number(&mut self, key_type: JsValue) -> Result<(), JsValue> {
+    pub fn set_key_type_number(&mut self, key_type: &JsValue) -> Result<(), JsValue> {
         self.set_key_type(key_type)
     }
 

--- a/packages/identity_public_key/src/lib.rs
+++ b/packages/identity_public_key/src/lib.rs
@@ -187,7 +187,9 @@ impl IdentityPublicKeyWASM {
     pub fn set_security_level(&mut self, security_level: &JsValue) -> Result<(), JsValue> {
         Ok(self
             .0
-            .set_security_level(SecurityLevel::from(SecurityLevelWASM::try_from(security_level.clone())?)))
+            .set_security_level(SecurityLevel::from(SecurityLevelWASM::try_from(
+                security_level.clone(),
+            )?)))
     }
 
     #[wasm_bindgen(setter = securityLevelNumber)]

--- a/packages/identity_transitions/src/create_transition/mod.rs
+++ b/packages/identity_transitions/src/create_transition/mod.rs
@@ -68,8 +68,8 @@ impl IdentityCreateTransitionWASM {
     }
 
     #[wasm_bindgen(js_name = "default")]
-    pub fn default(js_platform_version: JsValue) -> Result<IdentityCreateTransitionWASM, JsValue> {
-        let platform_version = PlatformVersionWASM::try_from(js_platform_version)?;
+    pub fn default(js_platform_version: &JsValue) -> Result<IdentityCreateTransitionWASM, JsValue> {
+        let platform_version = PlatformVersionWASM::try_from(js_platform_version.clone())?;
 
         IdentityCreateTransition::default_versioned(&platform_version.into())
             .map_err(|err| JsValue::from_str(&*err.to_string()))

--- a/packages/identity_transitions/src/credit_withdrawal_transition/mod.rs
+++ b/packages/identity_transitions/src/credit_withdrawal_transition/mod.rs
@@ -40,12 +40,12 @@ impl IdentityCreditWithdrawalTransitionWASM {
         js_identity_id: &JsValue,
         amount: u64,
         core_fee_per_byte: u32,
-        js_pooling: JsValue,
+        js_pooling: &JsValue,
+        nonce: IdentityNonce,
         js_output_script: &JsValue,
-        nonce: Option<IdentityNonce>,
         user_fee_increase: Option<UserFeeIncrease>,
     ) -> Result<IdentityCreditWithdrawalTransitionWASM, JsValue> {
-        let pooling = PoolingWASM::try_from(js_pooling)?;
+        let pooling = PoolingWASM::try_from(js_pooling.clone())?;
         let identity_id: Identifier = IdentifierWASM::try_from(js_identity_id)?.into();
 
         let output_script: Option<CoreScript> = match js_output_script.is_undefined() {
@@ -65,7 +65,7 @@ impl IdentityCreditWithdrawalTransitionWASM {
                 output_script,
                 core_fee_per_byte,
                 pooling: pooling.into(),
-                nonce: nonce.unwrap_or(0),
+                nonce,
                 user_fee_increase: user_fee_increase.unwrap_or(0),
                 signature_public_key_id: 0,
                 signature: Default::default(),
@@ -148,8 +148,8 @@ impl IdentityCreditWithdrawalTransitionWASM {
     }
 
     #[wasm_bindgen(setter = "pooling")]
-    pub fn set_pooling(&mut self, js_pooling: JsValue) -> Result<(), JsValue> {
-        let pooling: PoolingWASM = PoolingWASM::try_from(js_pooling)?;
+    pub fn set_pooling(&mut self, js_pooling: &JsValue) -> Result<(), JsValue> {
+        let pooling: PoolingWASM = PoolingWASM::try_from(js_pooling.clone())?;
         Ok(self.0.set_pooling(pooling.into()))
     }
 

--- a/packages/identity_transitions/src/identity_credit_transfer_transition/mod.rs
+++ b/packages/identity_transitions/src/identity_credit_transfer_transition/mod.rs
@@ -31,8 +31,8 @@ impl IdentityCreditTransferWASM {
 
     #[wasm_bindgen(constructor)]
     pub fn new(
-        amount: u64,
         js_sender: &JsValue,
+        amount: u64,
         js_recipient: &JsValue,
         nonce: u64,
         user_fee_increase: Option<UserFeeIncrease>,

--- a/packages/identity_transitions/src/public_key_in_creation/mod.rs
+++ b/packages/identity_transitions/src/public_key_in_creation/mod.rs
@@ -78,17 +78,17 @@ impl IdentityPublicKeyInCreationWASM {
     #[wasm_bindgen(constructor)]
     pub fn new(
         id: u32,
-        js_purpose: JsValue,
-        js_security_level: JsValue,
-        js_key_type: JsValue,
+        js_purpose: &JsValue,
+        js_security_level: &JsValue,
+        js_key_type: &JsValue,
         read_only: bool,
         binary_data: Vec<u8>,
         signature: Option<Vec<u8>>,
         js_contract_bounds: &JsValue,
     ) -> Result<IdentityPublicKeyInCreationWASM, JsValue> {
-        let purpose = PurposeWASM::try_from(js_purpose)?;
-        let security_level = SecurityLevelWASM::try_from(js_security_level)?;
-        let key_type = KeyTypeWASM::try_from(js_key_type)?;
+        let purpose = PurposeWASM::try_from(js_purpose.clone())?;
+        let security_level = SecurityLevelWASM::try_from(js_security_level.clone())?;
+        let key_type = KeyTypeWASM::try_from(js_key_type.clone())?;
         let contract_bounds: Option<ContractBounds> =
             match js_contract_bounds.is_undefined() | js_contract_bounds.is_null() {
                 true => None,
@@ -118,9 +118,9 @@ impl IdentityPublicKeyInCreationWASM {
     pub fn to_identity_public_key(&self) -> Result<IdentityPublicKeyWASM, JsValue> {
         IdentityPublicKeyWASM::new(
             self.0.id(),
-            JsValue::from(PurposeWASM::from(self.0.purpose())),
-            JsValue::from(SecurityLevelWASM::from(self.0.security_level())),
-            JsValue::from(KeyTypeWASM::from(self.0.key_type())),
+            &JsValue::from(PurposeWASM::from(self.0.purpose())),
+            &JsValue::from(SecurityLevelWASM::from(self.0.security_level())),
+            &JsValue::from(KeyTypeWASM::from(self.0.key_type())),
             self.0.read_only(),
             self.0.data().to_string(Hex).as_str(),
             None,
@@ -185,8 +185,8 @@ impl IdentityPublicKeyInCreationWASM {
     }
 
     #[wasm_bindgen(setter = purpose)]
-    pub fn set_purpose(&mut self, js_purpose: JsValue) -> Result<(), JsValue> {
-        let purpose = PurposeWASM::try_from(js_purpose)?;
+    pub fn set_purpose(&mut self, js_purpose: &JsValue) -> Result<(), JsValue> {
+        let purpose = PurposeWASM::try_from(js_purpose.clone())?;
         Ok(self.0.set_purpose(Purpose::from(purpose)))
     }
 

--- a/packages/masternode_vote/src/vote_poll/mod.rs
+++ b/packages/masternode_vote/src/vote_poll/mod.rs
@@ -40,7 +40,7 @@ impl VotePollWASM {
         js_contract_id: &JsValue,
         document_type_name: String,
         index_name: String,
-        js_index_values: JsValue,
+        js_index_values: &JsValue,
     ) -> Result<VotePollWASM, JsValue> {
         let contract_id = IdentifierWASM::try_from(js_contract_id)?;
 
@@ -151,7 +151,7 @@ impl VotePollWASM {
     }
 
     #[wasm_bindgen(setter = "indexValues")]
-    pub fn set_index_values(&mut self, js_index_values: JsValue) -> Result<(), JsValue> {
+    pub fn set_index_values(&mut self, js_index_values: &JsValue) -> Result<(), JsValue> {
         let index_values = match js_index_values.with_serde_to_platform_value()?.as_array() {
             None => Err(JsValue::from("index values must be array")),
             Some(array) => Ok(array.clone()),

--- a/packages/private_key/src/lib.rs
+++ b/packages/private_key/src/lib.rs
@@ -33,8 +33,8 @@ impl PrivateKeyWASM {
     }
 
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(bytes: Vec<u8>, js_network: JsValue) -> Result<Self, JsValue> {
-        let network = NetworkWASM::try_from(js_network)?;
+    pub fn from_bytes(bytes: Vec<u8>, js_network: &JsValue) -> Result<Self, JsValue> {
+        let network = NetworkWASM::try_from(js_network.clone())?;
 
         let pk = PrivateKey::from_slice(bytes.as_slice(), network.into())
             .map_err(|err| JsValue::from_str(&*err.to_string()))?;
@@ -43,8 +43,8 @@ impl PrivateKeyWASM {
     }
 
     #[wasm_bindgen(js_name = "fromHex")]
-    pub fn from_hex(hex_key: &str, js_network: JsValue) -> Result<Self, JsValue> {
-        let network = NetworkWASM::try_from(js_network)?;
+    pub fn from_hex(hex_key: &str, js_network: &JsValue) -> Result<Self, JsValue> {
+        let network = NetworkWASM::try_from(js_network.clone())?;
 
         let bytes = Vec::from_hex(hex_key).map_err(|err| JsValue::from(err.to_string()))?;
 

--- a/packages/state_transition/src/lib.rs
+++ b/packages/state_transition/src/lib.rs
@@ -90,11 +90,11 @@ impl StateTransitionWASM {
         &mut self,
         private_key: &PrivateKeyWASM,
         key_id: Option<KeyID>,
-        js_key_type: JsValue,
+        js_key_type: &JsValue,
     ) -> Result<Vec<u8>, JsValue> {
         let key_type = match js_key_type.is_undefined() {
             true => KeyTypeWASM::ECDSA_SECP256K1,
-            false => KeyTypeWASM::try_from(js_key_type)?,
+            false => KeyTypeWASM::try_from(js_key_type.clone())?,
         };
 
         let _sig = self

--- a/packages/token_configuration/src/distribution_function.rs
+++ b/packages/token_configuration/src/distribution_function.rs
@@ -74,8 +74,8 @@ impl DistributionFunctionWASM {
     }
 
     #[wasm_bindgen(js_name = "Stepwise")]
-    pub fn stepwise(js_steps_with_amount: JsValue) -> Result<DistributionFunctionWASM, JsValue> {
-        let obj = Object::from(js_steps_with_amount);
+    pub fn stepwise(js_steps_with_amount: &JsValue) -> Result<DistributionFunctionWASM, JsValue> {
+        let obj = Object::from(js_steps_with_amount.clone());
 
         let mut steps_with_amount: BTreeMap<u64, TokenAmount> = BTreeMap::new();
 

--- a/packages/token_configuration_change_item/src/items/perpetual_distribution.rs
+++ b/packages/token_configuration_change_item/src/items/perpetual_distribution.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 impl TokenConfigurationChangeItemWASM {
     #[wasm_bindgen(js_name = "PerpetualDistributionConfigurationItem")]
     pub fn perpetual_distribution_item(
-        js_perpetual_distribution_value: JsValue,
+        js_perpetual_distribution_value: &JsValue,
     ) -> Result<Self, JsValue> {
         let perpetual_distribution_value: Option<TokenPerpetualDistribution> =
             match js_perpetual_distribution_value.is_undefined() {

--- a/packages/verify/src/verify_contract/mod.rs
+++ b/packages/verify/src/verify_contract/mod.rs
@@ -4,8 +4,8 @@ use js_sys::Uint8Array;
 use pshenmic_dpp_data_contract::DataContractWASM;
 use pshenmic_dpp_enums::platform::PlatformVersionWASM;
 use pshenmic_dpp_identifier::IdentifierWASM;
-use wasm_bindgen::{JsError, JsValue};
 use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{JsError, JsValue};
 
 #[wasm_bindgen(js_name = "VerifiedContractWASM")]
 pub struct VerifiedContractWASM {

--- a/packages/verify/src/verify_contract/mod.rs
+++ b/packages/verify/src/verify_contract/mod.rs
@@ -4,7 +4,7 @@ use js_sys::Uint8Array;
 use pshenmic_dpp_data_contract::DataContractWASM;
 use pshenmic_dpp_enums::platform::PlatformVersionWASM;
 use pshenmic_dpp_identifier::IdentifierWASM;
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsError, JsValue};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 #[wasm_bindgen(js_name = "VerifiedContractWASM")]
@@ -38,7 +38,7 @@ impl VerifiedContractWASM {
 
 #[wasm_bindgen(js_name = "verifyContractProof")]
 pub fn verify_contract(
-    proof: &Uint8Array,
+    proof: &[u8],
     contract_known_keeps_history: Option<bool>,
     is_proof_subset: bool,
     in_multiple_contract_proof_form: bool,
@@ -49,14 +49,14 @@ pub fn verify_contract(
     let platform_version = PlatformVersionWASM::try_from(js_platform_version.clone())?;
 
     let (root_hash, contract_option) = Drive::verify_contract(
-        &proof.to_vec(),
+        proof,
         contract_known_keeps_history,
         is_proof_subset,
         in_multiple_contract_proof_form,
         contract_id.to_slice(),
         &platform_version.into(),
     )
-    .map_err(|e| JsValue::from(e.to_string()))?;
+    .map_err(|e| JsError::from(e))?;
 
     Ok(VerifiedContractWASM {
         root_hash,

--- a/packages/verify/src/verify_document/mod.rs
+++ b/packages/verify/src/verify_document/mod.rs
@@ -54,7 +54,7 @@ pub fn verify_document_proof(
     js_start_at: &JsValue,
     start_at_included: bool,
     block_time_ms: Option<u64>,
-    js_platform_version: JsValue,
+    js_platform_version: &JsValue,
 ) -> Result<VerifiedDocumentsWASM, JsValue> {
     let internal_clauses = match js_where_clauses.is_undefined() | js_order_by.is_null() {
         true => InternalClauses::default(),
@@ -69,7 +69,7 @@ pub fn verify_document_proof(
     let platform_version = match js_platform_version.is_undefined() | js_platform_version.is_null()
     {
         true => PlatformVersionWASM::default(),
-        false => PlatformVersionWASM::try_from(js_platform_version)?,
+        false => PlatformVersionWASM::try_from(js_platform_version.clone())?,
     };
 
     let order_by_map = parse_order_by_index_map(js_order_by)?;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,7 +9,7 @@ PROFILE=release
 
 OUTPUT_FILE="${PWD}/wasm/pshenmic_dpp_bg.wasm"
 
-#RUSTFLAGS="-C target-feature=+crt-static -C embed-bitcode=no -C metadata=reduced -C link-dead-code=no -C panic=abort"
+RUSTFLAGS="-C target-feature=+crt-static -C embed-bitcode=no -C metadata=reduced -C link-dead-code=no -C panic=abort"
 
 BUILD_COMMAND="cargo build --config net.git-fetch-with-cli=true --target=${TARGET} ${PROFILE_ARG}"
 STRIP_COMMAND="wasm-snip ${PWD}/target/${TARGET}/${PROFILE}/pshenmic_dpp.wasm -o ${PWD}/target/${TARGET}/${PROFILE}/pshenmic_dpp.wasm --snip-rust-fmt-code --snip-rust-panicking-code"
@@ -23,56 +23,56 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
   AR_PATH=$(command -v llvm-ar)
   CLANG_PATH=$(command -v clang)
   AR=${AR_PATH} CC=${CLANG_PATH} ${BUILD_COMMAND}
-#  AR=${AR_PATH} CC=${CLANG_PATH} ${STRIP_COMMAND}
+  AR=${AR_PATH} CC=${CLANG_PATH} ${STRIP_COMMAND}
   AR=${AR_PATH} CC=${CLANG_PATH} ${BINDGEN_COMMAND}
 else
   echo "Build"
   ${BUILD_COMMAND}
   echo "Strip"
-#  ${STRIP_COMMAND}
+  ${STRIP_COMMAND}
   echo "Bindgen"
   ${BINDGEN_COMMAND}
 fi
 
 if command -v wasm-opt &> /dev/null; then
   echo "Optimizing wasm using Binaryen"
-#  wasm-opt \
-#    --code-folding \
-#    --const-hoisting \
-#    --abstract-type-refining \
-#    --dce \
-#    --strip-producers \
-#    -Oz \
-#    --generate-global-effects \
-#    --enable-bulk-memory \
-#    --enable-nontrapping-float-to-int  \
-#    -tnh \
-#    --flatten \
-#    --rereloop \
-#    -Oz \
-#    --converge \
-#    --vacuum \
-#    --dce \
-#    --gsi \
-#    --inlining-optimizing \
-#    --merge-blocks \
-#    --simplify-locals \
-#    --optimize-added-constants \
-#    --optimize-casts \
-#    --optimize-instructions \
-#    --optimize-stack-ir \
-#    --remove-unused-brs \
-#    --remove-unused-module-elements \
-#    --remove-unused-names \
-#    --remove-unused-types \
-#    --post-emscripten \
-#    --gufa \
-#    --once-reduction \
-#    -Oz \
-#    -Oz \
-#    "${OUTPUT_FILE}" \
-#    -o \
-#    "${OUTPUT_FILE}"
+  wasm-opt \
+    --code-folding \
+    --const-hoisting \
+    --abstract-type-refining \
+    --dce \
+    --strip-producers \
+    -Oz \
+    --generate-global-effects \
+    --enable-bulk-memory \
+    --enable-nontrapping-float-to-int  \
+    -tnh \
+    --flatten \
+    --rereloop \
+    -Oz \
+    --converge \
+    --vacuum \
+    --dce \
+    --gsi \
+    --inlining-optimizing \
+    --merge-blocks \
+    --simplify-locals \
+    --optimize-added-constants \
+    --optimize-casts \
+    --optimize-instructions \
+    --optimize-stack-ir \
+    --remove-unused-brs \
+    --remove-unused-module-elements \
+    --remove-unused-names \
+    --remove-unused-types \
+    --post-emscripten \
+    --gufa \
+    --once-reduction \
+    -Oz \
+    -Oz \
+    "${OUTPUT_FILE}" \
+    -o \
+    "${OUTPUT_FILE}"
 
 else
   echo "wasm-opt command not found. Skipping wasm optimization."

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,7 +9,7 @@ PROFILE=release
 
 OUTPUT_FILE="${PWD}/wasm/pshenmic_dpp_bg.wasm"
 
-RUSTFLAGS="-C target-feature=+crt-static -C embed-bitcode=no -C metadata=reduced -C link-dead-code=no -C panic=abort"
+#RUSTFLAGS="-C target-feature=+crt-static -C embed-bitcode=no -C metadata=reduced -C link-dead-code=no -C panic=abort"
 
 BUILD_COMMAND="cargo build --config net.git-fetch-with-cli=true --target=${TARGET} ${PROFILE_ARG}"
 STRIP_COMMAND="wasm-snip ${PWD}/target/${TARGET}/${PROFILE}/pshenmic_dpp.wasm -o ${PWD}/target/${TARGET}/${PROFILE}/pshenmic_dpp.wasm --snip-rust-fmt-code --snip-rust-panicking-code"
@@ -23,56 +23,56 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
   AR_PATH=$(command -v llvm-ar)
   CLANG_PATH=$(command -v clang)
   AR=${AR_PATH} CC=${CLANG_PATH} ${BUILD_COMMAND}
-  AR=${AR_PATH} CC=${CLANG_PATH} ${STRIP_COMMAND}
+#  AR=${AR_PATH} CC=${CLANG_PATH} ${STRIP_COMMAND}
   AR=${AR_PATH} CC=${CLANG_PATH} ${BINDGEN_COMMAND}
 else
   echo "Build"
   ${BUILD_COMMAND}
   echo "Strip"
-  ${STRIP_COMMAND}
+#  ${STRIP_COMMAND}
   echo "Bindgen"
   ${BINDGEN_COMMAND}
 fi
 
 if command -v wasm-opt &> /dev/null; then
   echo "Optimizing wasm using Binaryen"
-  wasm-opt \
-    --code-folding \
-    --const-hoisting \
-    --abstract-type-refining \
-    --dce \
-    --strip-producers \
-    -Oz \
-    --generate-global-effects \
-    --enable-bulk-memory \
-    --enable-nontrapping-float-to-int  \
-    -tnh \
-    --flatten \
-    --rereloop \
-    -Oz \
-    --converge \
-    --vacuum \
-    --dce \
-    --gsi \
-    --inlining-optimizing \
-    --merge-blocks \
-    --simplify-locals \
-    --optimize-added-constants \
-    --optimize-casts \
-    --optimize-instructions \
-    --optimize-stack-ir \
-    --remove-unused-brs \
-    --remove-unused-module-elements \
-    --remove-unused-names \
-    --remove-unused-types \
-    --post-emscripten \
-    --gufa \
-    --once-reduction \
-    -Oz \
-    -Oz \
-    "${OUTPUT_FILE}" \
-    -o \
-    "${OUTPUT_FILE}"
+#  wasm-opt \
+#    --code-folding \
+#    --const-hoisting \
+#    --abstract-type-refining \
+#    --dce \
+#    --strip-producers \
+#    -Oz \
+#    --generate-global-effects \
+#    --enable-bulk-memory \
+#    --enable-nontrapping-float-to-int  \
+#    -tnh \
+#    --flatten \
+#    --rereloop \
+#    -Oz \
+#    --converge \
+#    --vacuum \
+#    --dce \
+#    --gsi \
+#    --inlining-optimizing \
+#    --merge-blocks \
+#    --simplify-locals \
+#    --optimize-added-constants \
+#    --optimize-casts \
+#    --optimize-instructions \
+#    --optimize-stack-ir \
+#    --remove-unused-brs \
+#    --remove-unused-module-elements \
+#    --remove-unused-names \
+#    --remove-unused-types \
+#    --post-emscripten \
+#    --gufa \
+#    --once-reduction \
+#    -Oz \
+#    -Oz \
+#    "${OUTPUT_FILE}" \
+#    -o \
+#    "${OUTPUT_FILE}"
 
 else
   echo "wasm-opt command not found. Skipping wasm optimization."

--- a/tests/IdentityCreditTransferTransition.spec.cjs
+++ b/tests/IdentityCreditTransferTransition.spec.cjs
@@ -5,7 +5,7 @@ const { default: wasm } = require('..')
 describe('IdentityCreditTransferTransition', function () {
   describe('serialization / deserialization', function () {
     it('Should create IdentityCreditTransferTransition with empty platform version', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       assert.notEqual(transition.__wbg_ptr, 0)
     })
@@ -14,7 +14,7 @@ describe('IdentityCreditTransferTransition', function () {
       const sender = new wasm.IdentifierWASM('11111111111111111111111111111111')
       const recipient = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
 
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), sender, recipient, BigInt(199), 'platform_v1')
+      const transition = new wasm.IdentityCreditTransferWASM(sender, BigInt(100), recipient, BigInt(199), 'platform_v1')
 
       assert.notEqual(transition.__wbg_ptr, 0)
       assert.notEqual(sender.__wbg_ptr, 0)
@@ -24,43 +24,43 @@ describe('IdentityCreditTransferTransition', function () {
 
   describe('getters', function () {
     it('Should return recipientId', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       assert.deepEqual(transition.recipientId.base58(), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
     })
 
     it('Should return senderId', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       assert.deepEqual(transition.senderId.base58(), '11111111111111111111111111111111')
     })
 
     it('Should return amount', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       assert.deepEqual(transition.amount, BigInt(100))
     })
 
     it('Should return nonce', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       assert.deepEqual(transition.nonce, BigInt(199))
     })
 
     it('Should return signature', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       assert.deepEqual(transition.signature, Uint8Array.from([]))
     })
 
     it('Should return signaturePublicKeyId', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       assert.deepEqual(transition.signaturePublicKeyId, 0)
     })
 
     it('Should return userFeeIncrease', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       assert.deepEqual(transition.userFeeIncrease, 0)
     })
@@ -68,7 +68,7 @@ describe('IdentityCreditTransferTransition', function () {
 
   describe('setters', function () {
     it('Should allow to set recipientId', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       const recipient = new wasm.IdentifierWASM('11111111111111111111111111111111')
 
@@ -83,7 +83,7 @@ describe('IdentityCreditTransferTransition', function () {
     })
 
     it('Should return senderId', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       const sender = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
 
@@ -98,7 +98,7 @@ describe('IdentityCreditTransferTransition', function () {
     })
 
     it('Should return amount', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       transition.amount = BigInt(199)
 
@@ -106,7 +106,7 @@ describe('IdentityCreditTransferTransition', function () {
     })
 
     it('Should return nonce', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       transition.nonce = BigInt(1)
 
@@ -114,7 +114,7 @@ describe('IdentityCreditTransferTransition', function () {
     })
 
     it('Should return signature', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       transition.signature = [1, 1]
 
@@ -122,7 +122,7 @@ describe('IdentityCreditTransferTransition', function () {
     })
 
     it('Should return signaturePublicKeyId', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       transition.signaturePublicKeyId = 11
 
@@ -130,7 +130,7 @@ describe('IdentityCreditTransferTransition', function () {
     })
 
     it('Should return userFeeIncrease', async function () {
-      const transition = new wasm.IdentityCreditTransferWASM(BigInt(100), '11111111111111111111111111111111', 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
+      const transition = new wasm.IdentityCreditTransferWASM('11111111111111111111111111111111', BigInt(100), 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec', BigInt(199))
 
       transition.userFeeIncrease = 11
 

--- a/tests/IdentityCreditWithdrawalTransition.spec.cjs
+++ b/tests/IdentityCreditWithdrawalTransition.spec.cjs
@@ -8,7 +8,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       assert.notEqual(identifier.__wbg_ptr, 0)
       assert.notEqual(script.__wbg_ptr, 0)
@@ -21,7 +21,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       assert.deepEqual(transition.outputScript.toString(), 'dqkUAQEBAQEBAQEBAQEBAQEBAQEBAQGIrA==')
     })
@@ -30,7 +30,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       assert.deepEqual(transition.pooling, 'Never')
     })
@@ -39,7 +39,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       assert.deepEqual(transition.identityId.base58(), identifier.base58())
     })
@@ -48,7 +48,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       assert.deepEqual(transition.userFeeIncrease, 1)
     })
@@ -57,7 +57,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       assert.deepEqual(transition.nonce, BigInt(1))
     })
@@ -66,7 +66,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       assert.deepEqual(transition.amount, BigInt(111))
     })
@@ -75,7 +75,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       assert.deepEqual(transition.signature, Uint8Array.from([]))
     })
@@ -84,7 +84,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       assert.deepEqual(transition.signaturePublicKeyId, 0)
     })
@@ -95,7 +95,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       const script2 = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
@@ -108,7 +108,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       transition.pooling = 'Standard'
 
@@ -119,7 +119,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       const identifier2 = new wasm.IdentifierWASM('11SAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
 
@@ -132,7 +132,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       transition.userFeeIncrease = 999
 
@@ -143,7 +143,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       transition.nonce = BigInt(1111)
 
@@ -154,7 +154,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       transition.amount = BigInt(2222)
 
@@ -165,7 +165,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       transition.signature = Uint8Array.from([1, 2, 3])
 
@@ -176,7 +176,7 @@ describe('IdentityCreditWithdrawalTransition', function () {
       const identifier = new wasm.IdentifierWASM('GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec')
       const script = wasm.CoreScriptWASM.newP2PKH([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
-      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', script, BigInt(1), 1)
+      const transition = new wasm.IdentityCreditWithdrawalTransitionWASM(identifier, BigInt(111), 1, 'never', BigInt(1), script, 1)
 
       transition.signaturePublicKeyId = 11
 


### PR DESCRIPTION
# Issue
We have memory leaks on verify contract method, which throws `memory acces out of bounds`

# Things done
- All JSValue now passes as link
- Fixed method for verify in our fork
- Bump versions
- Formatting identity transfer and withdrawal transitions
