### PR TITLE
Preparing the module for use in React Native

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,12 +1,12 @@
 import * as DPP from './pshenmic_dpp.js';
 
-export * from './pshenmic_dpp.js'
+export * from './pshenmic_dpp.js';
 
-export * from './base122.js'
+export * from './base122.js';
 
-export default dpp;
 
 declare const dpp: DashPlatformProtocolWASM;
+export default dpp;
 
 export class DashPlatformProtocolWASM {
     // CLASSES

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import * as DPP from './pshenmic_dpp.js'
-import { wasmBytes } from './pshenmic_dpp_bg.js'
+import { bytes as wasmBytes } from './pshenmic_dpp_bg.js'
 import { decode } from './base122.js'
 import { decompressSync } from 'fflate'
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import * as DPP from './pshenmic_dpp.js'
-import wasmBytes from './pshenmic_dpp_bg.js'
+import { wasmBytes } from './pshenmic_dpp_bg.js'
 import { decode } from './base122.js'
 import { decompressSync } from 'fflate'
 

--- a/lib/initAsync.d.ts
+++ b/lib/initAsync.d.ts
@@ -1,6 +1,4 @@
 import type {DashPlatformProtocolWASM} from "./index.d.ts";
 
-declare function initModule(): Promise<DashPlatformProtocolWASM>
-
-export default initModule;
 export type { DashPlatformProtocolWASM } from './index.d.ts';
+export function initModule(): Promise<DashPlatformProtocolWASM>

--- a/lib/initAsync.js
+++ b/lib/initAsync.js
@@ -1,5 +1,5 @@
-import initWASM from './initWASM.js'
-import initWASMInterface from './initInterface.js'
+import {initWASM} from './initWASM.js'
+import {initInterface} from './initInterface.js'
 
 // eslint-disable-next-line
 let dpp
@@ -8,13 +8,13 @@ let dpp
  * Asynchronously initialization for compressed module (reduced size)
  * @returns {Promise<*>}
  */
-async function initModule () {
+async function initModule() {
   const wasm = await initWASM()
-  const wasmInterface = await initWASMInterface()
+  const wasmInterface = await initInterface()
 
   dpp = wasmInterface.initSync(wasm)
 
   return wasmInterface
 }
 
-export default initModule
+export {initModule}

--- a/lib/initInterface.d.ts
+++ b/lib/initInterface.d.ts
@@ -1,5 +1,3 @@
 import type {DashPlatformProtocolWASM} from "./index.d.ts";
 
-declare function initModule(): Promise<DashPlatformProtocolWASM>
-
-export default initModule;
+export function initInterface(): Promise<DashPlatformProtocolWASM>

--- a/lib/initInterface.js
+++ b/lib/initInterface.js
@@ -1,4 +1,4 @@
-import wasmInterfaceBytes from './pshenmic_dpp_zipped.js'
+import {bytes as wasmInterfaceBytes} from './pshenmic_dpp_zipped.js'
 import { decode } from './base122.js'
 
 export * from './base122.js'

--- a/lib/initInterface.js
+++ b/lib/initInterface.js
@@ -42,4 +42,4 @@ async function initInterface () {
   return module
 }
 
-export default initInterface
+export { initInterface }

--- a/lib/initWASM.d.ts
+++ b/lib/initWASM.d.ts
@@ -1,2 +1,1 @@
-declare function _default(): Promise<ArrayBuffer>;
-export default _default;
+export function initWASM(): Promise<ArrayBuffer>;

--- a/lib/initWASM.js
+++ b/lib/initWASM.js
@@ -1,4 +1,4 @@
-import {wasmBytes} from './pshenmic_dpp_bg.js'
+import {bytes as wasmBytes} from './pshenmic_dpp_bg.js'
 import {decode} from './base122.js'
 
 export * from './base122.js'

--- a/lib/initWASM.js
+++ b/lib/initWASM.js
@@ -1,5 +1,5 @@
-import wasmBytes from './pshenmic_dpp_bg.js'
-import { decode } from './base122.js'
+import {wasmBytes} from './pshenmic_dpp_bg.js'
+import {decode} from './base122.js'
 
 export * from './base122.js'
 
@@ -16,7 +16,7 @@ const interfaceBlob = new Blob([interfaceBytes])
  * Convert wasm bin string to Uint8Array with decompression via DecompressionStream
  * @returns {Promise<ArrayBuffer>}
  */
-async function initWASM () {
+async function initWASM() {
   const decompressionStream = new DecompressionStream('gzip')
   const decompressedStream = interfaceBlob.stream().pipeThrough(decompressionStream)
   const decompressedResponse = new Response(decompressedStream)
@@ -25,4 +25,4 @@ async function initWASM () {
   return module
 }
 
-export default initWASM
+export {initWASM}

--- a/lib/pshenmic_dpp_zipped.d.ts
+++ b/lib/pshenmic_dpp_zipped.d.ts
@@ -1,0 +1,3 @@
+declare const binaryData: string;
+
+export default binaryData;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -65,7 +65,6 @@ if command -v wasm-opt &> /dev/null; then
     --remove-unused-module-elements \
     --remove-unused-names \
     --remove-unused-types \
-    --post-emscripten \
     --gufa \
     --once-reduction \
     -Oz \

--- a/tests/AsyncImportTest.spec.cjs
+++ b/tests/AsyncImportTest.spec.cjs
@@ -4,13 +4,13 @@ const {
   document, dataContractId, ownerId, documentTypeName, revision, dataContractValue, id, document2, documentBytes
 } = require('./mocks/Document/index.js')
 const { fromHexString } = require('./utils/hex')
-const {default: initWASM} = require('pshenmic-dpp/initAsync')
+const {initModule} = require('pshenmic-dpp/initAsync')
 
 let wasm
 
 describe('Async Import', function () {
   before(async () => {
-    wasm = await initWASM();
+    wasm = await initModule();
   })
 
   describe('Document', function () {

--- a/utils/convertBinary.mjs
+++ b/utils/convertBinary.mjs
@@ -25,7 +25,7 @@ gzip.on('data', data => {
 
 gzip.on('end', () => {
   const encodedData = Buffer.from(encode(compressedChunks)).toString('utf-8');
-  const outputContent = `const wasmBytes = "${encodedData}"\nexport {wasmBytes}`;
+  const outputContent = `const bytes = "${encodedData}"\nexport {bytes}`;
 
   fs.writeFileSync(outputFile, outputContent);
 

--- a/utils/convertBinary.mjs
+++ b/utils/convertBinary.mjs
@@ -25,7 +25,7 @@ gzip.on('data', data => {
 
 gzip.on('end', () => {
   const encodedData = Buffer.from(encode(compressedChunks)).toString('utf-8');
-  const outputContent = `export default "${encodedData}"`;
+  const outputContent = `const wasmBytes = "${encodedData}"\nexport {wasmBytes}`;
 
   fs.writeFileSync(outputFile, outputContent);
 


### PR DESCRIPTION
# Issue
We need to prepare the module for use in mobile applications in the React Native environment. 

# Things done
- Updated wasm-opt for copability
- Exports by default replaced with named exports in the largest number of non-generated files
- Very big react-native research

We conducted research on the possibilities of integrating pshenmic-dpp into react-native to enable the creation of mobile applications based on SDK and DPP.
There were several attempts, but the most successful ones were uniffi and the use of the wasm module as a turbo module.
Although Uniffi is noted as one of the possible options for launching dpp in the react-native environment, it is far from the desired result and requires a lot of effort, changing the package architecture, cutting back on the current capabilities of dynamic typing, and its implementation will take a very long time.
The second option is to use the `@callstack/polygen` tool to generate turbo modules from wasm. Unfortunately, we don't know the exact status of this package in the future, but the last update was 7 months ago, and the lead developer of this package has disappeared somewhere. At the moment, we have successfully updated it to work with pshenmic-dpp on iOS and are now preparing to launch it on Android, which is proving to be very difficult.

More detailed information about uniffi and polygen can be found in the reports #133 and #134
https://github.com/owl352/callstack-polygen
https://github.com/owl352/callstack-polygen-codegen