### PR TITLE
Incorrect getActionType values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.1.0-dev.7"
+version = "1.1.0-dev.8"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.1.0-dev.7"
+version = "1.1.0-dev.8"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.1.0-dev.7",
+  "version": "1.1.0-dev.8",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "type": "module",

--- a/packages/state_transition/src/lib.rs
+++ b/packages/state_transition/src/lib.rs
@@ -283,9 +283,25 @@ impl StateTransitionWASM {
         Ok(Sha256::digest(payload).to_hex_string(Lower))
     }
 
+    #[wasm_bindgen(js_name = "getActionName")]
+    pub fn get_action_name(&self) -> String {
+        self.0.name()
+    }
+
     #[wasm_bindgen(js_name = "getActionType")]
     pub fn get_action_type(&self) -> String {
-        self.0.name()
+        match self.0 {
+            DataContractCreate(_) => "DATA_CONTRACT_CREATE",
+            Batch(_) => "BATCH",
+            StateTransition::IdentityCreate(_) => "IDENTITY_CREATE",
+            IdentityTopUp(_) => "IDENTITY_TOP_UP",
+            DataContractUpdate(_) => "DATA_CONTRACT_UPDATE",
+            IdentityUpdate(_) => "IDENTITY_UPDATE",
+            IdentityCreditWithdrawal(_) => "IDENTITY_CREDIT_WITHDRAWAL",
+            IdentityCreditTransfer(_) => "IDENTITY_CREDIT_TRANSFER",
+            MasternodeVote(_) => "MASTERNODE_VOTE",
+        }
+        .to_string()
     }
 
     #[wasm_bindgen(js_name = "getActionTypeNumber")]


### PR DESCRIPTION
# Issue
at this moment `getActionType` returns incorrect values for batch, like `DocumentsBatch(DocumentCreateTransition)`

# Things done
- Updated `getActionType`
- Added `getActionName` with `DocumentsBatch(DocumentCreateTransition)`
- Bump