### PR TITLE
KeyId format fix for verifyIdentityKeysByIdentifierProof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.1.2-dev.3"
+version = "1.1.2-dev.4"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.1.2-dev.3"
+version = "1.1.2-dev.4"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.1.2-dev.3",
+  "version": "1.1.2-dev.4",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "type": "module",

--- a/packages/verify/src/verify_identity/verify_identity_keys_by_identifier.rs
+++ b/packages/verify/src/verify_identity/verify_identity_keys_by_identifier.rs
@@ -58,7 +58,8 @@ pub fn verify_identity_keys_by_identifier(
             let key_id: KeyID = keys_array
                 .get(i)
                 .as_f64()
-                .ok_or_else(|| JsValue::from_str("Key ID must be a number"))? as u32;
+                .ok_or_else(|| JsValue::from_str("Key ID must be a number"))?
+                as u32;
 
             keys_vec.push(key_id);
         }

--- a/packages/verify/src/verify_identity/verify_identity_keys_by_identifier.rs
+++ b/packages/verify/src/verify_identity/verify_identity_keys_by_identifier.rs
@@ -1,3 +1,4 @@
+use dpp::identity::KeyID;
 use drive::drive::Drive;
 use drive::drive::identity::key::fetch::{IdentityKeysRequest, KeyRequestType};
 use drive::verify::RootHash;
@@ -54,12 +55,11 @@ pub fn verify_identity_keys_by_identifier(
     let request_type = if let Some(keys_array) = specific_key_ids {
         let mut keys_vec = Vec::new();
         for i in 0..keys_array.length() {
-            let key_id = keys_array
+            let key_id: KeyID = keys_array
                 .get(i)
-                .as_string()
-                .ok_or_else(|| JsValue::from_str("Key ID must be a string"))?
-                .parse::<u32>()
-                .map_err(|_| JsValue::from_str("Invalid key ID number"))?;
+                .as_f64()
+                .ok_or_else(|| JsValue::from_str("Key ID must be a number"))? as u32;
+
             keys_vec.push(key_id);
         }
         KeyRequestType::SpecificKeys(keys_vec)


### PR DESCRIPTION
# Issue
At this moment we pass key id as array of string, but thats incorrect, we need to pass number

# Things done
- Fixed valuda deserialization
- Bump