### PR TITLE
Dynamic type for arguments with private key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.1.2-dev.5"
+version = "1.1.2-dev.6"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,6 +2220,7 @@ name = "pshenmic_dpp_private_key"
 version = "1.0.5"
 dependencies = [
  "dpp",
+ "js-sys",
  "pshenmic_dpp_enums",
  "pshenmic_dpp_public_key",
  "pshenmic_dpp_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,6 +2222,7 @@ dependencies = [
  "dpp",
  "pshenmic_dpp_enums",
  "pshenmic_dpp_public_key",
+ "pshenmic_dpp_utils",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.1.2-dev.5"
+version = "1.1.2-dev.6"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.1.2-dev.5",
+  "version": "1.1.2-dev.6",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "type": "module",

--- a/packages/enums/src/network/mod.rs
+++ b/packages/enums/src/network/mod.rs
@@ -65,3 +65,15 @@ impl From<NetworkWASM> for Network {
         }
     }
 }
+
+impl From<Network> for NetworkWASM {
+    fn from(network: Network) -> Self {
+        match network {
+            Network::Dash => NetworkWASM::Mainnet,
+            Network::Testnet => NetworkWASM::Testnet,
+            Network::Devnet => NetworkWASM::Devnet,
+            Network::Regtest => NetworkWASM::Regtest,
+            _ => NetworkWASM::Testnet,
+        }
+    }
+}

--- a/packages/identity_public_key/src/public_key.rs
+++ b/packages/identity_public_key/src/public_key.rs
@@ -92,8 +92,8 @@ impl IdentityPublicKeyWASM {
 
 #[wasm_bindgen]
 impl IdentityPublicKeyWASM {
-    #[wasm_bindgen(js_name = "validatePrivateKey")]
-    pub fn validate_private_key(
+    #[wasm_bindgen(js_name = "validatePrivateKeyBytes")]
+    pub fn validate_private_key_bytes(
         &self,
         js_private_key_bytes: Vec<u8>,
         js_network: &JsValue,
@@ -250,13 +250,9 @@ impl IdentityPublicKeyWASM {
         self.0.is_master()
     }
 
-    #[wasm_bindgen(js_name = "validatePrivateKeyBytes")]
-    pub fn validate_private_key_bytes(
-        &self,
-        private_key: &PrivateKeyWASM,
-        js_network: JsValue,
-    ) -> Result<bool, JsValue> {
-        let network: NetworkWASM = js_network.try_into()?;
+    #[wasm_bindgen(js_name = "validatePrivateKey")]
+    pub fn validate_private_key(&self, js_private_key: &JsValue) -> Result<bool, JsValue> {
+        let private_key = PrivateKeyWASM::try_from(js_private_key.clone())?;
 
         self.0
             .validate_private_key_bytes(
@@ -265,7 +261,7 @@ impl IdentityPublicKeyWASM {
                     .as_slice()
                     .try_into()
                     .map_err(|_| JsValue::from("Cannot convert vec<u8> to [u8; 32]"))?,
-                network.into(),
+                private_key.network(),
             )
             .with_js_error()
     }

--- a/packages/identity_public_key/src/public_key.rs
+++ b/packages/identity_public_key/src/public_key.rs
@@ -251,8 +251,8 @@ impl IdentityPublicKeyWASM {
     }
 
     #[wasm_bindgen(js_name = "validatePrivateKey")]
-    pub fn validate_private_key(&self, js_private_key: &JsValue) -> Result<bool, JsValue> {
-        let private_key = PrivateKeyWASM::try_from(js_private_key.clone())?;
+    pub fn validate_private_key(&self, js_private_key: &JsValue, js_network: &JsValue) -> Result<bool, JsValue> {
+        let private_key = PrivateKeyWASM::from_js_value(js_private_key, js_network)?;
 
         self.0
             .validate_private_key_bytes(

--- a/packages/identity_public_key/src/public_key.rs
+++ b/packages/identity_public_key/src/public_key.rs
@@ -251,7 +251,11 @@ impl IdentityPublicKeyWASM {
     }
 
     #[wasm_bindgen(js_name = "validatePrivateKey")]
-    pub fn validate_private_key(&self, js_private_key: &JsValue, js_network: &JsValue) -> Result<bool, JsValue> {
+    pub fn validate_private_key(
+        &self,
+        js_private_key: &JsValue,
+        js_network: &JsValue,
+    ) -> Result<bool, JsValue> {
         let private_key = PrivateKeyWASM::from_js_value(js_private_key, js_network)?;
 
         self.0

--- a/packages/identity_public_key/src/public_key_in_creation.rs
+++ b/packages/identity_public_key/src/public_key_in_creation.rs
@@ -129,7 +129,11 @@ impl IdentityPublicKeyInCreationWASM {
     }
 
     #[wasm_bindgen(js_name = "validatePrivateKey")]
-    pub fn validate_private_key(&self, js_private_key: &JsValue, js_network: &JsValue) -> Result<bool, JsValue> {
+    pub fn validate_private_key(
+        &self,
+        js_private_key: &JsValue,
+        js_network: &JsValue,
+    ) -> Result<bool, JsValue> {
         let public_key: IdentityPublicKeyWASM = IdentityPublicKey::from(self.clone()).into();
 
         public_key.validate_private_key(js_private_key, js_network)

--- a/packages/identity_public_key/src/public_key_in_creation.rs
+++ b/packages/identity_public_key/src/public_key_in_creation.rs
@@ -129,10 +129,10 @@ impl IdentityPublicKeyInCreationWASM {
     }
 
     #[wasm_bindgen(js_name = "validatePrivateKey")]
-    pub fn validate_private_key(&self, js_private_key: &JsValue) -> Result<bool, JsValue> {
+    pub fn validate_private_key(&self, js_private_key: &JsValue, js_network: &JsValue) -> Result<bool, JsValue> {
         let public_key: IdentityPublicKeyWASM = IdentityPublicKey::from(self.clone()).into();
 
-        public_key.validate_private_key(js_private_key)
+        public_key.validate_private_key(js_private_key, js_network)
     }
 
     #[wasm_bindgen(js_name = "getHash")]

--- a/packages/identity_public_key/src/public_key_in_creation.rs
+++ b/packages/identity_public_key/src/public_key_in_creation.rs
@@ -13,7 +13,6 @@ use pshenmic_dpp_contract_bounds::ContractBoundsWASM;
 use pshenmic_dpp_enums::keys::key_type::KeyTypeWASM;
 use pshenmic_dpp_enums::keys::purpose::PurposeWASM;
 use pshenmic_dpp_enums::keys::security_level::SecurityLevelWASM;
-use pshenmic_dpp_private_key::PrivateKeyWASM;
 use pshenmic_dpp_utils::{IntoWasm, WithJsError};
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -130,14 +129,10 @@ impl IdentityPublicKeyInCreationWASM {
     }
 
     #[wasm_bindgen(js_name = "validatePrivateKey")]
-    pub fn validate_private_key(
-        &self,
-        private_key: &PrivateKeyWASM,
-        js_network: JsValue,
-    ) -> Result<bool, JsValue> {
+    pub fn validate_private_key(&self, js_private_key: &JsValue) -> Result<bool, JsValue> {
         let public_key: IdentityPublicKeyWASM = IdentityPublicKey::from(self.clone()).into();
 
-        public_key.validate_private_key_bytes(private_key, js_network)
+        public_key.validate_private_key(js_private_key)
     }
 
     #[wasm_bindgen(js_name = "getHash")]

--- a/packages/private_key/Cargo.toml
+++ b/packages/private_key/Cargo.toml
@@ -11,6 +11,7 @@ wasm-bindgen = { workspace = true }
 dpp = { workspace = true, features = [
     "identity-value-conversion",
 ]}
+js-sys = { workspace = true }
 pshenmic_dpp_enums = {path = "../enums"}
 pshenmic_dpp_utils = {path = "../utils"}
 pshenmic_dpp_public_key = {path = "../public_key"}

--- a/packages/private_key/Cargo.toml
+++ b/packages/private_key/Cargo.toml
@@ -12,4 +12,5 @@ dpp = { workspace = true, features = [
     "identity-value-conversion",
 ]}
 pshenmic_dpp_enums = {path = "../enums"}
+pshenmic_dpp_utils = {path = "../utils"}
 pshenmic_dpp_public_key = {path = "../public_key"}

--- a/packages/private_key/src/lib.rs
+++ b/packages/private_key/src/lib.rs
@@ -7,59 +7,13 @@ use dpp::dashcore::{Network, PrivateKey, base58};
 use pshenmic_dpp_enums::network::NetworkWASM;
 use pshenmic_dpp_public_key::PublicKeyWASM;
 use pshenmic_dpp_utils::{IntoWasm, get_class_type};
-use std::fmt::format;
+use js_sys::Uint8Array;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 #[derive(Debug, Clone)]
 #[wasm_bindgen(js_name = "PrivateKeyWASM")]
 pub struct PrivateKeyWASM(PrivateKey);
-
-impl TryFrom<JsValue> for PrivateKeyWASM {
-    type Error = JsValue;
-    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
-        match value.is_string() {
-            true => {
-                let str = value
-                    .as_string()
-                    .ok_or(JsValue::from_str("Invalid string"))?;
-
-                if str.len() == 64 {
-                    // raw hex
-                    Err(JsValue::from_str(
-                        "Private Key Bytes not allowed here please use wif",
-                    ))
-                } else {
-                    // base58 check
-                    let key_base58 = base58::decode_check(&str).map_err(|err| {
-                        JsValue::from(format!("Private Key error read wif ({})", err))
-                    })?;
-
-                    if key_base58.clone().len() == 33 || key_base58.clone().len() == 34 {
-                        PrivateKeyWASM::from_wif(&str)
-                    } else {
-                        Err(JsValue::from(format!(
-                            "Private key decoded wif must be 38 byte length ({})",
-                            key_base58.clone().len()
-                        )))
-                    }
-                }
-            }
-            false => match value.is_object() {
-                true => {
-                    if get_class_type(&value)?.as_str() == "PrivateKeyWASM" {
-                        Ok(value.to_wasm::<PrivateKeyWASM>("PrivateKeyWASM")?.clone())
-                    } else {
-                        Err(JsValue::from_str(
-                            "Cannot parse object as instance of PrivateKeyWASM",
-                        ))
-                    }
-                }
-                false => Err(JsValue::from("Cannot parse private key"))?,
-            },
-        }
-    }
-}
 
 #[wasm_bindgen]
 impl PrivateKeyWASM {
@@ -71,6 +25,11 @@ impl PrivateKeyWASM {
     #[wasm_bindgen(getter = __struct)]
     pub fn struct_name() -> String {
         "PrivateKeyWASM".to_string()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(value: &JsValue, js_network: &JsValue) -> Result<PrivateKeyWASM, JsValue> {
+        PrivateKeyWASM::from_js_value(value, js_network)
     }
 
     #[wasm_bindgen(js_name = "fromWIF")]
@@ -171,5 +130,51 @@ impl PrivateKeyWASM {
 impl PrivateKeyWASM {
     pub fn network(&self) -> Network {
         self.0.network
+    }
+
+    pub fn from_js_value(value: &JsValue, js_network: &JsValue) -> Result<Self, JsValue> {
+        match value.is_string() {
+            true => {
+                let str = value
+                    .as_string()
+                    .ok_or(JsValue::from_str("Invalid string"))?;
+
+                if str.len() == 64 {
+                    // raw hex
+                    if js_network.is_undefined() {
+                        Err(JsValue::from_str("You must specify a network when pass private key hex as arguments"))
+                    } else{
+                        PrivateKeyWASM::from_hex(&str, js_network)
+                    }
+                } else {
+                    // base58 check
+                    let key_base58 = base58::decode_check(&str).map_err(|err| {
+                        JsValue::from(format!("Private Key error read wif ({})", err))
+                    })?;
+
+                    if key_base58.clone().len() == 33 || key_base58.clone().len() == 34 {
+                        PrivateKeyWASM::from_wif(&str)
+                    } else {
+                        Err(JsValue::from(format!(
+                            "Private key decoded wif must be 38 byte length ({})",
+                            key_base58.clone().len()
+                        )))
+                    }
+                }
+            }
+            false => match value.is_object() || value.is_array() {
+                true => {
+                    if get_class_type(&value) == Ok("PrivateKeyWASM".to_string()) {
+                        Ok(value.to_wasm::<PrivateKeyWASM>("PrivateKeyWASM")?.clone())
+                    } else {
+                        let uint8_array = Uint8Array::from(value.clone());
+                        let bytes = uint8_array.to_vec();
+
+                        PrivateKeyWASM::from_bytes(bytes, js_network)
+                    }
+                }
+                false => Err(JsValue::from("Cannot parse private key"))?,
+            },
+        }
     }
 }

--- a/packages/private_key/src/lib.rs
+++ b/packages/private_key/src/lib.rs
@@ -4,10 +4,10 @@ use dpp::dashcore::secp256k1::Message;
 use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use dpp::dashcore::signer::{CompactSignature, double_sha};
 use dpp::dashcore::{Network, PrivateKey, base58};
+use js_sys::Uint8Array;
 use pshenmic_dpp_enums::network::NetworkWASM;
 use pshenmic_dpp_public_key::PublicKeyWASM;
 use pshenmic_dpp_utils::{IntoWasm, get_class_type};
-use js_sys::Uint8Array;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -142,8 +142,10 @@ impl PrivateKeyWASM {
                 if str.len() == 64 {
                     // raw hex
                     if js_network.is_undefined() {
-                        Err(JsValue::from_str("You must specify a network when pass private key hex as arguments"))
-                    } else{
+                        Err(JsValue::from_str(
+                            "You must specify a network when pass private key hex as arguments",
+                        ))
+                    } else {
                         PrivateKeyWASM::from_hex(&str, js_network)
                     }
                 } else {

--- a/packages/private_key/src/lib.rs
+++ b/packages/private_key/src/lib.rs
@@ -1,17 +1,65 @@
-use dpp::dashcore::PrivateKey;
 use dpp::dashcore::hashes::hex::FromHex;
 use dpp::dashcore::key::Secp256k1;
 use dpp::dashcore::secp256k1::Message;
 use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use dpp::dashcore::signer::{CompactSignature, double_sha};
+use dpp::dashcore::{Network, PrivateKey, base58};
 use pshenmic_dpp_enums::network::NetworkWASM;
 use pshenmic_dpp_public_key::PublicKeyWASM;
+use pshenmic_dpp_utils::{IntoWasm, get_class_type};
+use std::fmt::format;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[wasm_bindgen(js_name = "PrivateKeyWASM")]
 pub struct PrivateKeyWASM(PrivateKey);
+
+impl TryFrom<JsValue> for PrivateKeyWASM {
+    type Error = JsValue;
+    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
+        match value.is_string() {
+            true => {
+                let str = value
+                    .as_string()
+                    .ok_or(JsValue::from_str("Invalid string"))?;
+
+                if str.len() == 64 {
+                    // raw hex
+                    Err(JsValue::from_str(
+                        "Private Key Bytes not allowed here please use wif",
+                    ))
+                } else {
+                    // base58 check
+                    let key_base58 = base58::decode_check(&str).map_err(|err| {
+                        JsValue::from(format!("Private Key error read wif ({})", err))
+                    })?;
+
+                    if key_base58.clone().len() == 33 || key_base58.clone().len() == 34 {
+                        PrivateKeyWASM::from_wif(&str)
+                    } else {
+                        Err(JsValue::from(format!(
+                            "Private key decoded wif must be 38 byte length ({})",
+                            key_base58.clone().len()
+                        )))
+                    }
+                }
+            }
+            false => match value.is_object() {
+                true => {
+                    if get_class_type(&value)?.as_str() == "PrivateKeyWASM" {
+                        Ok(value.to_wasm::<PrivateKeyWASM>("PrivateKeyWASM")?.clone())
+                    } else {
+                        Err(JsValue::from_str(
+                            "Cannot parse object as instance of PrivateKeyWASM",
+                        ))
+                    }
+                }
+                false => Err(JsValue::from("Cannot parse private key"))?,
+            },
+        }
+    }
+}
 
 #[wasm_bindgen]
 impl PrivateKeyWASM {
@@ -69,6 +117,11 @@ impl PrivateKeyWASM {
 
 #[wasm_bindgen]
 impl PrivateKeyWASM {
+    #[wasm_bindgen(js_name = "getNetwork")]
+    pub fn get_network(&self) -> String {
+        NetworkWASM::from(self.0.network).into()
+    }
+
     #[wasm_bindgen(js_name = "WIF")]
     pub fn get_wif(&self) -> String {
         self.0.to_wif()
@@ -112,5 +165,11 @@ impl PrivateKeyWASM {
             .to_compact_signature(self.0.compressed);
 
         Ok(signature.to_vec())
+    }
+}
+
+impl PrivateKeyWASM {
+    pub fn network(&self) -> Network {
+        self.0.network
     }
 }

--- a/packages/state_transition/src/lib.rs
+++ b/packages/state_transition/src/lib.rs
@@ -71,9 +71,11 @@ impl StateTransitionWASM {
     #[wasm_bindgen(js_name = "sign")]
     pub fn sign(
         &mut self,
-        private_key: &PrivateKeyWASM,
+        js_private_key: &JsValue,
         public_key: &IdentityPublicKeyWASM,
     ) -> Result<Vec<u8>, JsValue> {
+        let private_key = PrivateKeyWASM::try_from(js_private_key.clone())?;
+
         self.0
             .sign(
                 &public_key.clone().into(),
@@ -88,10 +90,12 @@ impl StateTransitionWASM {
     #[wasm_bindgen(js_name = "signByPrivateKey")]
     pub fn sign_by_private_key(
         &mut self,
-        private_key: &PrivateKeyWASM,
+        js_private_key: &JsValue,
         key_id: Option<KeyID>,
         js_key_type: &JsValue,
     ) -> Result<Vec<u8>, JsValue> {
+        let private_key = PrivateKeyWASM::try_from(js_private_key.clone())?;
+
         let key_type = match js_key_type.is_undefined() {
             true => KeyTypeWASM::ECDSA_SECP256K1,
             false => KeyTypeWASM::try_from(js_key_type.clone())?,

--- a/packages/state_transition/src/lib.rs
+++ b/packages/state_transition/src/lib.rs
@@ -73,7 +73,7 @@ impl StateTransitionWASM {
         &mut self,
         js_private_key: &JsValue,
         public_key: &IdentityPublicKeyWASM,
-        js_network: &JsValue
+        js_network: &JsValue,
     ) -> Result<Vec<u8>, JsValue> {
         let private_key = PrivateKeyWASM::from_js_value(js_private_key, js_network)?;
 
@@ -94,7 +94,7 @@ impl StateTransitionWASM {
         js_private_key: &JsValue,
         key_id: Option<KeyID>,
         js_key_type: &JsValue,
-        js_network: &JsValue
+        js_network: &JsValue,
     ) -> Result<Vec<u8>, JsValue> {
         let private_key = PrivateKeyWASM::from_js_value(js_private_key, js_network)?;
 

--- a/packages/state_transition/src/lib.rs
+++ b/packages/state_transition/src/lib.rs
@@ -73,8 +73,9 @@ impl StateTransitionWASM {
         &mut self,
         js_private_key: &JsValue,
         public_key: &IdentityPublicKeyWASM,
+        js_network: &JsValue
     ) -> Result<Vec<u8>, JsValue> {
-        let private_key = PrivateKeyWASM::try_from(js_private_key.clone())?;
+        let private_key = PrivateKeyWASM::from_js_value(js_private_key, js_network)?;
 
         self.0
             .sign(
@@ -93,8 +94,9 @@ impl StateTransitionWASM {
         js_private_key: &JsValue,
         key_id: Option<KeyID>,
         js_key_type: &JsValue,
+        js_network: &JsValue
     ) -> Result<Vec<u8>, JsValue> {
-        let private_key = PrivateKeyWASM::try_from(js_private_key.clone())?;
+        let private_key = PrivateKeyWASM::from_js_value(js_private_key, js_network)?;
 
         let key_type = match js_key_type.is_undefined() {
             true => KeyTypeWASM::ECDSA_SECP256K1,

--- a/tests/IdentityPublicKey.spec.cjs
+++ b/tests/IdentityPublicKey.spec.cjs
@@ -97,7 +97,35 @@ describe('PublicKey', function () {
       assert.equal(pubKey.validatePrivateKey(privateKey), false)
     })
 
-    it('should allow to validate private key by wif', function () {
+    it('should allow to validate private key bytes', function () {
+      const pubKey = new wasm.IdentityPublicKeyWASM(
+        keyId,
+        purpose,
+        securityLevel,
+        keyType,
+        false,
+        binaryData)
+
+      const privateKey = wasm.PrivateKeyWASM.fromWIF(wif)
+
+      assert.equal(pubKey.validatePrivateKey(privateKey.bytes(), wasm.NetworkWASM.Mainnet), false)
+    })
+
+    it('should allow to validate private key hex', function () {
+      const pubKey = new wasm.IdentityPublicKeyWASM(
+        keyId,
+        purpose,
+        securityLevel,
+        keyType,
+        false,
+        binaryData)
+
+      const privateKey = wasm.PrivateKeyWASM.fromWIF(wif)
+
+      assert.equal(pubKey.validatePrivateKey(privateKey.hex(), wasm.NetworkWASM.Mainnet), false)
+    })
+
+    it('should allow to validate private key wif', function () {
       const pubKey = new wasm.IdentityPublicKeyWASM(
         keyId,
         purpose,

--- a/tests/IdentityPublicKey.spec.cjs
+++ b/tests/IdentityPublicKey.spec.cjs
@@ -94,7 +94,19 @@ describe('PublicKey', function () {
 
       const privateKey = wasm.PrivateKeyWASM.fromWIF(wif)
 
-      assert.equal(pubKey.validatePrivateKey(privateKey.bytes(), wasm.NetworkWASM.Mainnet), false)
+      assert.equal(pubKey.validatePrivateKey(privateKey), false)
+    })
+
+    it('should allow to validate private key by wif', function () {
+      const pubKey = new wasm.IdentityPublicKeyWASM(
+        keyId,
+        purpose,
+        securityLevel,
+        keyType,
+        false,
+        binaryData)
+
+      assert.equal(pubKey.validatePrivateKey(wif), false)
     })
   })
 


### PR DESCRIPTION
# Issue
At this moment user must pass `PrivateKeyWASM` when method requires private key, but thats incorrect

# Things done
- Added methods which allows to get private key from js env with dynamic type of arg
- Updated methods args, now to some methods you can pass network if you use private key hex or bytes
- New tests
- Bump