### PR TITLE
Sign by private key bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.1.2-dev.6"
+version = "1.1.2-dev.7"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.1.2-dev.6"
+version = "1.1.2-dev.7"
 edition = "2024"
 rust-version = "1.85"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.1.2-dev.6",
+  "version": "1.1.2-dev.7",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "type": "module",

--- a/packages/private_key/src/lib.rs
+++ b/packages/private_key/src/lib.rs
@@ -4,7 +4,7 @@ use dpp::dashcore::secp256k1::Message;
 use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use dpp::dashcore::signer::{CompactSignature, double_sha};
 use dpp::dashcore::{Network, PrivateKey, base58};
-use dpp::platform_value::string_encoding::{decode, Encoding};
+use dpp::platform_value::string_encoding::{Encoding, decode};
 use js_sys::Uint8Array;
 use pshenmic_dpp_enums::network::NetworkWASM;
 use pshenmic_dpp_public_key::PublicKeyWASM;
@@ -190,7 +190,10 @@ impl PrivateKeyWASM {
 
                 if str.len() == 64 {
                     // raw hex
-                    Ok(decode(&str, Encoding::Hex).map_err(|err| JsValue::from(err.to_string()))?)
+                    Ok(
+                        decode(&str, Encoding::Hex)
+                            .map_err(|err| JsValue::from(err.to_string()))?,
+                    )
                 } else {
                     // base58 check
                     let key_base58 = base58::decode_check(&str).map_err(|err| {
@@ -210,10 +213,13 @@ impl PrivateKeyWASM {
             false => match value.is_object() || value.is_array() {
                 true => {
                     if get_class_type(&value) == Ok("PrivateKeyWASM".to_string()) {
-                        Ok(value.to_wasm::<PrivateKeyWASM>("PrivateKeyWASM")?.clone().get_bytes())
+                        Ok(value
+                            .to_wasm::<PrivateKeyWASM>("PrivateKeyWASM")?
+                            .clone()
+                            .get_bytes())
                     } else {
                         let uint8_array = Uint8Array::from(value.clone());
-                        
+
                         Ok(uint8_array.to_vec())
                     }
                 }

--- a/packages/private_key/src/lib.rs
+++ b/packages/private_key/src/lib.rs
@@ -4,6 +4,7 @@ use dpp::dashcore::secp256k1::Message;
 use dpp::dashcore::secp256k1::hashes::hex::{Case, DisplayHex};
 use dpp::dashcore::signer::{CompactSignature, double_sha};
 use dpp::dashcore::{Network, PrivateKey, base58};
+use dpp::platform_value::string_encoding::{decode, Encoding};
 use js_sys::Uint8Array;
 use pshenmic_dpp_enums::network::NetworkWASM;
 use pshenmic_dpp_public_key::PublicKeyWASM;
@@ -173,6 +174,47 @@ impl PrivateKeyWASM {
                         let bytes = uint8_array.to_vec();
 
                         PrivateKeyWASM::from_bytes(bytes, js_network)
+                    }
+                }
+                false => Err(JsValue::from("Cannot parse private key"))?,
+            },
+        }
+    }
+
+    pub fn bytes_from_js_value(value: &JsValue) -> Result<Vec<u8>, JsValue> {
+        match value.is_string() {
+            true => {
+                let str = value
+                    .as_string()
+                    .ok_or(JsValue::from_str("Invalid string"))?;
+
+                if str.len() == 64 {
+                    // raw hex
+                    Ok(decode(&str, Encoding::Hex).map_err(|err| JsValue::from(err.to_string()))?)
+                } else {
+                    // base58 check
+                    let key_base58 = base58::decode_check(&str).map_err(|err| {
+                        JsValue::from(format!("Private Key error read wif ({})", err))
+                    })?;
+
+                    if key_base58.clone().len() == 33 || key_base58.clone().len() == 34 {
+                        Ok(PrivateKeyWASM::from_wif(&str)?.get_bytes())
+                    } else {
+                        Err(JsValue::from(format!(
+                            "Private key decoded wif must be 38 byte length ({})",
+                            key_base58.clone().len()
+                        )))
+                    }
+                }
+            }
+            false => match value.is_object() || value.is_array() {
+                true => {
+                    if get_class_type(&value) == Ok("PrivateKeyWASM".to_string()) {
+                        Ok(value.to_wasm::<PrivateKeyWASM>("PrivateKeyWASM")?.clone().get_bytes())
+                    } else {
+                        let uint8_array = Uint8Array::from(value.clone());
+                        
+                        Ok(uint8_array.to_vec())
                     }
                 }
                 false => Err(JsValue::from("Cannot parse private key"))?,

--- a/packages/state_transition/src/lib.rs
+++ b/packages/state_transition/src/lib.rs
@@ -73,14 +73,13 @@ impl StateTransitionWASM {
         &mut self,
         js_private_key: &JsValue,
         public_key: &IdentityPublicKeyWASM,
-        js_network: &JsValue,
     ) -> Result<Vec<u8>, JsValue> {
-        let private_key = PrivateKeyWASM::from_js_value(js_private_key, js_network)?;
+        let private_key_bytes = PrivateKeyWASM::bytes_from_js_value(js_private_key)?;
 
         self.0
             .sign(
                 &public_key.clone().into(),
-                private_key.get_bytes().as_slice(),
+                private_key_bytes.as_slice(),
                 &MockBLS {},
             )
             .with_js_error()?;
@@ -94,9 +93,8 @@ impl StateTransitionWASM {
         js_private_key: &JsValue,
         key_id: Option<KeyID>,
         js_key_type: &JsValue,
-        js_network: &JsValue,
     ) -> Result<Vec<u8>, JsValue> {
-        let private_key = PrivateKeyWASM::from_js_value(js_private_key, js_network)?;
+        let private_key_bytes = PrivateKeyWASM::bytes_from_js_value(js_private_key)?;
 
         let key_type = match js_key_type.is_undefined() {
             true => KeyTypeWASM::ECDSA_SECP256K1,
@@ -106,7 +104,7 @@ impl StateTransitionWASM {
         let _sig = self
             .0
             .sign_by_private_key(
-                &private_key.get_bytes().as_slice(),
+                &private_key_bytes.as_slice(),
                 KeyType::from(key_type),
                 &MockBLS {},
             )


### PR DESCRIPTION
# Issue
At this moment for sign we use private key or bytes for private key and network for `PrivateKeyWASM` creation, but we can sign without `PrivateKeyWASM`, because sign methods use only bytes for private key

# Things done
- Implemented method which can get private key bytes from dynamic value types (bytes, hex, wif, PrivateKeyWASM)
- Updated sign methods for `StateTransitionWASM`
- Bump