### PR TITLE
Migrate to Platform 3.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
 
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: 1.92.0
 
     - name: Install rustfmt component
       run: rustup component add rustfmt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.92.0
 
       - name: Install rustfmt component
         run: rustup component add rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,52 +3,13 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -61,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -76,44 +37,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayref"
@@ -129,13 +90,13 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -146,24 +107,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
-]
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
@@ -188,15 +134,21 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bincode"
@@ -219,15 +171,15 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -235,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitvec"
@@ -253,15 +205,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -270,7 +223,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
 ]
 
 [[package]]
@@ -292,7 +245,7 @@ dependencies = [
  "sha2",
  "sha3",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "uint-zigzag",
  "vsss-rs",
  "zeroize",
@@ -339,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -351,32 +304,32 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -386,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-oid"
@@ -398,9 +351,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -442,7 +395,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "rand_core",
  "serdect",
  "subtle",
@@ -455,14 +408,41 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "dash-network"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "hex",
  "serde",
@@ -471,35 +451,36 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "anyhow",
  "base64-compat",
- "bech32",
+ "bech32 0.9.1",
  "bitvec",
  "blake3",
  "blsful",
  "dash-network",
  "dashcore-private",
  "dashcore_hashes",
+ "ed25519-dalek",
  "hex",
  "hex_lit",
  "log",
  "rustversion",
  "secp256k1",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "dashcore-private"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 
 [[package]]
 name = "dashcore_hashes"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "dashcore-private",
  "secp256k1",
@@ -508,13 +489,13 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "2.1.3"
-source = "git+https://github.com/owl352/platform?rev=3f13188#3f1318887530c7b6e75241b0d391ea1b35fdc42f"
+version = "3.0.0-rc.1"
+source = "git+https://github.com/owl352/platform?rev=3a4fd23#3a4fd23ee995a0b2c6d79da515183764fe410dba"
 dependencies = [
  "platform-value",
  "platform-version",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "token-history-contract",
  "withdrawals-contract",
 ]
@@ -546,7 +527,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
  "unicode-xid",
 ]
 
@@ -569,17 +550,18 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "dpp"
-version = "2.1.3"
-source = "git+https://github.com/owl352/platform?rev=3f13188#3f1318887530c7b6e75241b0d391ea1b35fdc42f"
+version = "3.0.0-rc.1"
+source = "git+https://github.com/owl352/platform?rev=3a4fd23#3a4fd23ee995a0b2c6d79da515183764fe410dba"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "bech32 0.11.1",
  "bincode",
  "bincode_derive",
  "bs58",
@@ -589,14 +571,14 @@ dependencies = [
  "data-contracts",
  "derive_more",
  "env_logger",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "hex",
  "indexmap",
  "integer-encoding",
  "itertools 0.13.0",
  "lazy_static",
  "nohash-hasher",
- "num_enum 0.7.3",
+ "num_enum 0.7.5",
  "once_cell",
  "platform-serialization",
  "platform-serialization-derive",
@@ -610,14 +592,14 @@ dependencies = [
  "serde_repr",
  "sha2",
  "strum",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
 [[package]]
 name = "drive"
-version = "2.1.3"
-source = "git+https://github.com/owl352/platform?rev=3f13188#3f1318887530c7b6e75241b0d391ea1b35fdc42f"
+version = "3.0.0-rc.1"
+source = "git+https://github.com/owl352/platform?rev=3a4fd23#3a4fd23ee995a0b2c6d79da515183764fe410dba"
 dependencies = [
  "bincode",
  "byteorder",
@@ -634,7 +616,7 @@ dependencies = [
  "nohash-hasher",
  "platform-version",
  "sqlparser",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -660,6 +642,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,7 +682,7 @@ dependencies = [
  "crypto-bigint",
  "digest",
  "ff",
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "group",
  "hkdf",
  "pkcs8",
@@ -711,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
  "regex",
@@ -740,12 +747,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -766,10 +773,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -853,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -864,50 +889,45 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.2.0"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
+checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
 dependencies = [
- "serde",
+ "rustversion",
+ "serde_core",
  "typenum",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
@@ -924,14 +944,14 @@ dependencies = [
 
 [[package]]
 name = "grovedb"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12b2378c5eda5b7cadceb34fc6e0a8fd87fe03fc04841a7d32a74ff73ccef71"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "bincode",
  "bincode_derive",
  "blake3",
  "grovedb-costs",
+ "grovedb-element",
  "grovedb-merk",
  "grovedb-path",
  "grovedb-version",
@@ -941,38 +961,49 @@ dependencies = [
  "integer-encoding",
  "reqwest",
  "sha2",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "grovedb-costs"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74fafe53bf5ae27128799856e557ef5cb2d7109f1f7bc7f4440bbd0f97c7072"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "integer-encoding",
  "intmap",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "grovedb-element"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+dependencies = [
+ "bincode",
+ "bincode_derive",
+ "grovedb-path",
+ "grovedb-version",
+ "hex",
+ "integer-encoding",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6bdc033cc229b17cd02ee9d5c5a5a344788ed0e69ad7468b0d34d94b021fc4"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "grovedb-costs",
  "hex",
  "integer-encoding",
  "intmap",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "grovedb-merk"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dd6f733e9d5c15c98e05b68a2028e00b7f177baa51e8d8c1541102942a72b7"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -980,39 +1011,37 @@ dependencies = [
  "byteorder",
  "ed",
  "grovedb-costs",
+ "grovedb-element",
  "grovedb-path",
  "grovedb-version",
  "grovedb-visualize",
  "hex",
  "indexmap",
  "integer-encoding",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "grovedb-path"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f716520d6c6b0f25dc4a68bc7dded645826ed57d38a06a80716a487c09d23c"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "hex",
 ]
 
 [[package]]
 name = "grovedb-version"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc855662f05f41b10dd022226cb78e345a33f35c390e25338d21dedd45966ae"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grovedb-visualize"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fa6f41c110d1d141bf912175f187ef51ac5d2a8f163dfd229be007461a548f"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -1020,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1048,19 +1077,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "ahash",
- "allocator-api2",
+ "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heapless"
@@ -1080,9 +1102,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1092,18 +1114,18 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
 
 [[package]]
 name = "hex-literal"
-version = "0.4.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hex_lit"
@@ -1131,12 +1153,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1171,9 +1192,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1225,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
@@ -1251,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1275,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1288,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1301,11 +1322,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1316,42 +1336,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1382,39 +1398,29 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "integer-encoding"
-version = "4.0.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d762194228a2f1c11063e46e32e5acb96e66e906382b9eb5441f2e0504bbd5a"
+checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
 
 [[package]]
 name = "intmap"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16dd999647b7a027fadf2b3041a4ea9c8ae21562823fe5cbdecd46537d535ae2"
+checksum = "a2e611826a1868311677fdcdfbec9e8621d104c732d080f546a854530232f0ee"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -1425,9 +1431,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -1435,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1459,32 +1465,32 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1514,43 +1520,42 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "merlin"
@@ -1571,33 +1576,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "multiexp"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a383da1ae933078ddb1e4141f1dd617b512b4183779d6977e6451b0e644806"
+checksum = "7ec2ce93a6f06ac6cae04c1da3f2a6a24fcfc1f0eb0b4e0f3d302f0df45326cb"
 dependencies = [
  "ff",
  "group",
+ "rand_core",
  "rustversion",
  "std-shims",
  "zeroize",
@@ -1725,11 +1722,12 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
- "num_enum_derive 0.7.3",
+ "num_enum_derive 0.7.5",
+ "rustversion",
 ]
 
 [[package]]
@@ -1746,23 +1744,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1773,15 +1762,15 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1800,7 +1789,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1811,9 +1800,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -1866,8 +1855,8 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platform-serialization"
-version = "2.1.3"
-source = "git+https://github.com/owl352/platform?rev=3f13188#3f1318887530c7b6e75241b0d391ea1b35fdc42f"
+version = "3.0.0-rc.1"
+source = "git+https://github.com/owl352/platform?rev=3a4fd23#3a4fd23ee995a0b2c6d79da515183764fe410dba"
 dependencies = [
  "bincode",
  "platform-version",
@@ -1875,19 +1864,19 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "2.1.3"
-source = "git+https://github.com/owl352/platform?rev=3f13188#3f1318887530c7b6e75241b0d391ea1b35fdc42f"
+version = "3.0.0-rc.1"
+source = "git+https://github.com/owl352/platform?rev=3a4fd23#3a4fd23ee995a0b2c6d79da515183764fe410dba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
  "virtue 0.0.17",
 ]
 
 [[package]]
 name = "platform-value"
-version = "2.1.3"
-source = "git+https://github.com/owl352/platform?rev=3f13188#3f1318887530c7b6e75241b0d391ea1b35fdc42f"
+version = "3.0.0-rc.1"
+source = "git+https://github.com/owl352/platform?rev=3a4fd23#3a4fd23ee995a0b2c6d79da515183764fe410dba"
 dependencies = [
  "base64",
  "bincode",
@@ -1899,37 +1888,37 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "treediff",
 ]
 
 [[package]]
 name = "platform-version"
-version = "2.1.3"
-source = "git+https://github.com/owl352/platform?rev=3f13188#3f1318887530c7b6e75241b0d391ea1b35fdc42f"
+version = "3.0.0-rc.1"
+source = "git+https://github.com/owl352/platform?rev=3a4fd23#3a4fd23ee995a0b2c6d79da515183764fe410dba"
 dependencies = [
  "bincode",
  "grovedb-version",
  "once_cell",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "versioned-feature-core 1.0.0 (git+https://github.com/dashpay/versioned-feature-core)",
 ]
 
 [[package]]
 name = "platform-versioning"
-version = "2.1.3"
-source = "git+https://github.com/owl352/platform?rev=3f13188#3f1318887530c7b6e75241b0d391ea1b35fdc42f"
+version = "3.0.0-rc.1"
+source = "git+https://github.com/owl352/platform?rev=3a4fd23#3a4fd23ee995a0b2c6d79da515183764fe410dba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1942,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -1970,18 +1959,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.22.26",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2002,6 +1991,7 @@ dependencies = [
  "pshenmic_dpp_identity_transitions",
  "pshenmic_dpp_masternode_vote",
  "pshenmic_dpp_partial_identity",
+ "pshenmic_dpp_platform_address",
  "pshenmic_dpp_state_transition",
  "pshenmic_dpp_verify",
  "talc",
@@ -2177,6 +2167,7 @@ dependencies = [
  "pshenmic_dpp_enums",
  "pshenmic_dpp_identifier",
  "pshenmic_dpp_identity_public_key",
+ "pshenmic_dpp_platform_address",
  "pshenmic_dpp_state_transition",
  "pshenmic_dpp_utils",
  "wasm-bindgen",
@@ -2211,6 +2202,19 @@ dependencies = [
  "js-sys",
  "pshenmic_dpp_identifier",
  "pshenmic_dpp_identity_public_key",
+ "pshenmic_dpp_utils",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "pshenmic_dpp_platform_address"
+version = "1.0.5"
+dependencies = [
+ "dpp",
+ "js-sys",
+ "pshenmic_dpp_asset_lock_proof",
+ "pshenmic_dpp_enums",
+ "pshenmic_dpp_identifier",
  "pshenmic_dpp_utils",
  "wasm-bindgen",
 ]
@@ -2302,6 +2306,7 @@ dependencies = [
  "pshenmic_dpp_identity",
  "pshenmic_dpp_masternode_vote",
  "pshenmic_dpp_partial_identity",
+ "pshenmic_dpp_platform_address",
  "pshenmic_dpp_state_transition",
  "pshenmic_dpp_utils",
  "wasm-bindgen",
@@ -2309,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -2355,7 +2360,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2369,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2381,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2392,15 +2397,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.23"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -2446,36 +2451,39 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2486,18 +2494,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2506,23 +2514,23 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2539,7 +2547,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "pkcs8",
  "subtle",
  "zeroize",
@@ -2581,20 +2589,27 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -2618,27 +2633,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2649,7 +2674,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2702,6 +2727,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,22 +2749,19 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -2753,17 +2784,18 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-shims"
-version = "0.1.1"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e49360f31b0b75a6a82a5205c6103ea07a79a60808d44f5cc879d303337926"
+checksum = "227c4f8561598188d0df96dbe749824576174bba278b5b6bb2eacff1066067d0"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
+ "rustversion",
  "spin",
 ]
 
@@ -2786,7 +2818,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2808,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2834,7 +2866,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2875,15 +2907,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2897,11 +2929,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -2912,18 +2944,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2937,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2947,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2962,30 +2994,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "2.1.3"
-source = "git+https://github.com/owl352/platform?rev=3f13188#3f1318887530c7b6e75241b0d391ea1b35fdc42f"
+version = "3.0.0-rc.1"
+source = "git+https://github.com/owl352/platform?rev=3a4fd23#3a4fd23ee995a0b2c6d79da515183764fe410dba"
 dependencies = [
  "platform-value",
  "platform-version",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
- "slab",
  "socket2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3000,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -3010,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3023,9 +3052,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3034,26 +3072,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
- "winnow 0.7.10",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3066,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3096,9 +3144,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3107,20 +3155,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -3139,9 +3187,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uint-zigzag"
@@ -3154,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-xid"
@@ -3172,9 +3220,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3237,7 +3285,7 @@ dependencies = [
  "crypto-bigint",
  "elliptic-curve",
  "elliptic-curve-tools",
- "generic-array 1.2.0",
+ "generic-array 1.3.5",
  "hex",
  "num",
  "rand_core",
@@ -3258,15 +3306,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -3316,7 +3364,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -3341,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -3354,37 +3402,37 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -3393,18 +3441,18 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -3415,16 +3463,25 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3433,14 +3490,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3450,10 +3524,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3462,10 +3548,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3474,10 +3572,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3486,10 +3596,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3502,23 +3624,23 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "withdrawals-contract"
-version = "2.1.3"
-source = "git+https://github.com/owl352/platform?rev=3f13188#3f1318887530c7b6e75241b0d391ea1b35fdc42f"
+version = "3.0.0-rc.1"
+source = "git+https://github.com/owl352/platform?rev=3a4fd23#3a4fd23ee995a0b2c6d79da515183764fe410dba"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",
@@ -3526,14 +3648,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wyz"
@@ -3546,11 +3668,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -3558,34 +3679,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3605,35 +3726,35 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3642,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3653,11 +3774,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "1.1.2-dev.7"
+version = "1.1.2-dev.8"
 dependencies = [
  "bincode",
  "bincode_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,11 @@
 name = "pshenmic-dpp"
 version = "1.1.2-dev.7"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.92"
 
 [workspace.dependencies]
-dpp = { git = "https://github.com/owl352/platform", rev = "3f13188", default-features = false }
-drive = { git = "https://github.com/owl352/platform", rev = "3f13188", default-features = false }
+dpp = { git = "https://github.com/owl352/platform", rev = "3a4fd23", default-features = false }
+drive = { git = "https://github.com/owl352/platform", rev = "3a4fd23", default-features = false }
 wasm-bindgen = { version = "=0.2.105", default-features = false, features = ["std"]}
 js-sys = { version = "0.3.78" }
 serde-wasm-bindgen = { git = "https://github.com/QuantumExplorer/serde-wasm-bindgen", branch = "feat/not_human_readable" }
@@ -41,7 +41,8 @@ members = [
     "packages/public_key",
     "packages/consensus_error",
     "packages/verify",
-    "packages/partial_identity"]
+    "packages/partial_identity",
+    "packages/platform_address"]
 
 [lib]
 crate-type = ["cdylib", "lib"]
@@ -62,6 +63,7 @@ pshenmic_dpp_data_contract = { path = "packages/data_contract" }
 pshenmic_dpp_data_contract_transitions = { path = "packages/data_contract_transitions" }
 pshenmic_dpp_enums = { path = "packages/enums" }
 pshenmic_dpp_masternode_vote = {path = "packages/masternode_vote"}
+pshenmic_dpp_platform_address = {path = "packages/platform_address"}
 
 [profile.release]
 lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pshenmic-dpp"
-version = "1.1.2-dev.7"
+version = "1.1.2-dev.8"
 edition = "2024"
 rust-version = "1.92"
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,11 @@
 import * as DPP from './pshenmic_dpp.js';
+import {
+  AddressCreditWithdrawalTransitionWASM, AddressFundingFromAssetLockTransitionWASM,
+  AddressFundsFeeStrategyStepWASM, AddressFundsTransferTransitionWASM, AddressWitnessWASM,
+  IdentityCreateFromAddressesTransitionWASM, IdentityCreditTransferToAddressesTransitionWASM,
+  IdentityTopUpFromAddressesTransitionWASM, InputAddressWASM, OutputAddressWASM,
+  PlatformAddressWASM, RecipientAddressWASM
+} from "../wasm/pshenmic_dpp";
 
 export * from './pshenmic_dpp.js';
 
@@ -93,6 +100,19 @@ export class DashPlatformProtocolWASM {
     VoteWASM: DPP.VoteWASM
     VotePollWASM: DPP.VotePollWASM
     ResourceVoteChoiceWASM: DPP.ResourceVoteChoiceWASM
+    AddressCreditWithdrawalTransitionWASM: DPP.AddressCreditWithdrawalTransitionWASM
+    AddressFundingFromAssetLockTransitionWASM: DPP.AddressFundingFromAssetLockTransitionWASM
+    AddressFundsFeeStrategyStepWASM: DPP.AddressFundsFeeStrategyStepWASM
+    AddressFundsTransferTransitionWASM: DPP.AddressFundsTransferTransitionWASM
+    IdentityCreateFromAddressesTransitionWASM: DPP.IdentityCreateFromAddressesTransitionWASM
+    IdentityCreditTransferToAddressesTransitionWASM: DPP.IdentityCreditTransferToAddressesTransitionWASM
+    OutputAddressWASM: DPP.OutputAddressWASM
+    InputAddressWASM: DPP.InputAddressWASM
+    IdentityTopUpFromAddressesTransitionWASM: DPP.IdentityTopUpFromAddressesTransitionWASM
+    RecipientAddressWASM: DPP.RecipientAddressWASM
+    AddressWitnessWASM: DPP.AddressWitnessWASM
+    PlatformAddressWASM: DPP.PlatformAddressWASM
+
     // ENUMS
     AssetLockProofTypeWASM: DPP.AssetLockProofTypeWASM
     BatchType: DPP.BatchType

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "1.1.2-dev.7",
+  "version": "1.1.2-dev.8",
   "main": "dist/wasm/index.js",
   "types": "dist/wasm/index.d.ts",
   "type": "module",

--- a/packages/batch/src/lib.rs
+++ b/packages/batch/src/lib.rs
@@ -14,7 +14,10 @@ use dpp::state_transition::batch_transition::methods::v0::DocumentsBatchTransiti
 use dpp::state_transition::batch_transition::{
     BatchTransition, BatchTransitionV0, BatchTransitionV1,
 };
-use dpp::state_transition::{StateTransition, StateTransitionIdentitySigned, StateTransitionLike};
+use dpp::state_transition::{
+    StateTransition, StateTransitionIdentitySigned, StateTransitionLike, StateTransitionOwned,
+    StateTransitionSingleSigned,
+};
 use pshenmic_dpp_identifier::IdentifierWASM;
 use pshenmic_dpp_state_transition::StateTransitionWASM;
 use pshenmic_dpp_utils::{IntoWasm, WithJsError};

--- a/packages/enums/src/platform/mod.rs
+++ b/packages/enums/src/platform/mod.rs
@@ -9,6 +9,7 @@ use dpp::version::v7::PLATFORM_V7;
 use dpp::version::v8::PLATFORM_V8;
 use dpp::version::v9::PLATFORM_V9;
 use dpp::version::v10::PLATFORM_V10;
+use dpp::version::v11::PLATFORM_V11;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -25,8 +26,9 @@ pub enum PlatformVersionWASM {
     PLATFORM_V7 = 7,
     PLATFORM_V8 = 8,
     PLATFORM_V9 = 9,
-    #[default]
     PLATFORM_V10 = 10,
+    #[default]
+    PLATFORM_V11 = 11,
 }
 
 impl TryFrom<JsValue> for PlatformVersionWASM {
@@ -46,6 +48,7 @@ impl TryFrom<JsValue> for PlatformVersionWASM {
                     "platform_v8" => Ok(PlatformVersionWASM::PLATFORM_V8),
                     "platform_v9" => Ok(PlatformVersionWASM::PLATFORM_V9),
                     "platform_v10" => Ok(PlatformVersionWASM::PLATFORM_V10),
+                    "platform_v11" => Ok(PlatformVersionWASM::PLATFORM_V11),
                     _ => Err(JsValue::from(format!(
                         "unknown platform version value: {}",
                         enum_val
@@ -65,6 +68,7 @@ impl TryFrom<JsValue> for PlatformVersionWASM {
                     8 => Ok(PlatformVersionWASM::PLATFORM_V8),
                     9 => Ok(PlatformVersionWASM::PLATFORM_V9),
                     10 => Ok(PlatformVersionWASM::PLATFORM_V10),
+                    11 => Ok(PlatformVersionWASM::PLATFORM_V11),
                     _ => Err(JsValue::from(format!(
                         "unknown platform version value: {}",
                         enum_val
@@ -88,6 +92,7 @@ impl From<PlatformVersionWASM> for String {
             PlatformVersionWASM::PLATFORM_V8 => String::from("PLATFORM_V8"),
             PlatformVersionWASM::PLATFORM_V9 => String::from("PLATFORM_V9"),
             PlatformVersionWASM::PLATFORM_V10 => String::from("PLATFORM_V10"),
+            PlatformVersionWASM::PLATFORM_V11 => String::from("PLATFORM_V11"),
         }
     }
 }
@@ -105,6 +110,7 @@ impl From<PlatformVersionWASM> for PlatformVersion {
             PlatformVersionWASM::PLATFORM_V8 => PLATFORM_V8,
             PlatformVersionWASM::PLATFORM_V9 => PLATFORM_V9,
             PlatformVersionWASM::PLATFORM_V10 => PLATFORM_V10,
+            PlatformVersionWASM::PLATFORM_V11 => PLATFORM_V11,
         }
     }
 }

--- a/packages/identity_transitions/src/address_transitions/address_credit_withdrawal_transition/mod.rs
+++ b/packages/identity_transitions/src/address_transitions/address_credit_withdrawal_transition/mod.rs
@@ -1,0 +1,290 @@
+use crate::address_transitions::address_funds_fee_step::AddressFundsFeeStrategyStepWASM;
+use crate::address_transitions::input_address::InputAddressWASM;
+use crate::address_transitions::output_address::OutputAddressWASM;
+use dpp::address_funds::{AddressWitness, PlatformAddress};
+use dpp::fee::Credits;
+use dpp::prelude::{AddressNonce, UserFeeIncrease};
+use dpp::state_transition::address_credit_withdrawal_transition::AddressCreditWithdrawalTransition;
+use dpp::state_transition::address_credit_withdrawal_transition::accessors::AddressCreditWithdrawalTransitionAccessorsV0;
+use dpp::state_transition::address_credit_withdrawal_transition::v0::AddressCreditWithdrawalTransitionV0;
+use dpp::state_transition::{
+    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionLike,
+    StateTransitionWitnessSigned,
+};
+use js_sys::Array;
+use pshenmic_dpp_core_script::CoreScriptWASM;
+use pshenmic_dpp_enums::withdrawal::PoolingWASM;
+use pshenmic_dpp_platform_address::address_witness::AddressWitnessWASM;
+use pshenmic_dpp_state_transition::StateTransitionWASM;
+use pshenmic_dpp_utils::IntoWasm;
+use std::collections::BTreeMap;
+use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Clone)]
+#[wasm_bindgen(js_name = "AddressCreditWithdrawalTransitionWASM")]
+pub struct AddressCreditWithdrawalTransitionWASM(AddressCreditWithdrawalTransition);
+
+impl From<AddressCreditWithdrawalTransition> for AddressCreditWithdrawalTransitionWASM {
+    fn from(v: AddressCreditWithdrawalTransition) -> Self {
+        AddressCreditWithdrawalTransitionWASM(v)
+    }
+}
+
+impl From<AddressCreditWithdrawalTransitionWASM> for AddressCreditWithdrawalTransition {
+    fn from(v: AddressCreditWithdrawalTransitionWASM) -> Self {
+        v.0
+    }
+}
+
+#[wasm_bindgen]
+impl AddressCreditWithdrawalTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "AddressCreditWithdrawalTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "AddressCreditWithdrawalTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        js_inputs: &JsValue,
+        js_fee_strategy: Vec<AddressFundsFeeStrategyStepWASM>,
+        core_fee_per_byte: u32,
+        js_pooling: &JsValue,
+        js_output_script: &CoreScriptWASM,
+        user_fee_increase: UserFeeIncrease,
+        js_input_witnesses: &JsValue,
+        js_output: &JsValue,
+    ) -> Result<AddressCreditWithdrawalTransitionWASM, JsValue> {
+        let pooling = PoolingWASM::try_from(js_pooling.clone())?;
+
+        let js_array_inputs = Array::from(js_inputs);
+        let inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = js_array_inputs
+            .iter()
+            .map(|js_input| {
+                let input = js_input
+                    .to_wasm::<InputAddressWASM>("InputAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, (AddressNonce, Credits)), JsValue>((
+                    PlatformAddress::from(input.address),
+                    (input.nonce, input.credits),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, (AddressNonce, Credits)>, JsValue>>()?;
+
+        let js_array_input_witnesses = Array::from(js_input_witnesses);
+        let input_witnesses = js_array_input_witnesses
+            .iter()
+            .map(|js_input| {
+                Ok::<AddressWitness, JsValue>(
+                    js_input
+                        .to_wasm::<AddressWitnessWASM>("AddressWitnessWASM")?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<AddressWitness>, JsValue>>()?;
+
+        let output: Option<(PlatformAddress, Credits)> = match js_output.is_null_or_undefined() {
+            true => None,
+            false => {
+                let converted_output = js_output
+                    .to_wasm::<OutputAddressWASM>("OutputAddressWASM")?
+                    .clone();
+
+                Some((converted_output.address.into(), converted_output.credits))
+            }
+        };
+
+        Ok(AddressCreditWithdrawalTransitionWASM(
+            AddressCreditWithdrawalTransition::V0(AddressCreditWithdrawalTransitionV0 {
+                inputs,
+                output,
+                fee_strategy: js_fee_strategy
+                    .iter()
+                    .map(|step| step.clone().into())
+                    .collect(),
+                core_fee_per_byte,
+                pooling: pooling.into(),
+                output_script: js_output_script.clone().into(),
+                user_fee_increase,
+                input_witnesses,
+            }),
+        ))
+    }
+
+    #[wasm_bindgen(getter = "coreFeePerByte")]
+    pub fn core_fee_per_byte(&self) -> u32 {
+        self.0.core_fee_per_byte()
+    }
+
+    #[wasm_bindgen(getter = "pooling")]
+    pub fn pooling(&self) -> PoolingWASM {
+        self.0.pooling().into()
+    }
+
+    #[wasm_bindgen(getter = "outputScript")]
+    pub fn output_script(&self) -> CoreScriptWASM {
+        self.0.output_script().clone().into()
+    }
+
+    #[wasm_bindgen(getter = "inputs")]
+    pub fn inputs(&self) -> Vec<InputAddressWASM> {
+        self.0
+            .inputs()
+            .iter()
+            .map(|(address, (nonce, credits))| InputAddressWASM {
+                address: address.clone().into(),
+                nonce: nonce.clone(),
+                credits: credits.clone(),
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "output")]
+    pub fn output(&self) -> Option<OutputAddressWASM> {
+        self.0.output().map(|(address, credits)| OutputAddressWASM {
+            address: address.clone().into(),
+            credits: credits.clone(),
+        })
+    }
+
+    #[wasm_bindgen(getter = "feeStrategy")]
+    pub fn fee_strategy(&self) -> Vec<AddressFundsFeeStrategyStepWASM> {
+        self.0
+            .fee_strategy()
+            .iter()
+            .map(|step| AddressFundsFeeStrategyStepWASM::from(step.clone()))
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "userFeeIncrease")]
+    pub fn user_fee_increase(&self) -> UserFeeIncrease {
+        self.0.user_fee_increase()
+    }
+
+    #[wasm_bindgen(getter = "inputWitness")]
+    pub fn input_witness(&self) -> Vec<AddressWitnessWASM> {
+        self.0
+            .witnesses()
+            .iter()
+            .map(|witness| AddressWitnessWASM::from(witness.clone()))
+            .collect()
+    }
+
+    #[wasm_bindgen(setter = "coreFeePerByte")]
+    pub fn set_core_fee_per_byte(&mut self, core_fee_per_byte: u32) {
+        self.0.set_core_fee_per_byte(core_fee_per_byte)
+    }
+
+    #[wasm_bindgen(setter = "pooling")]
+    pub fn set_pooling(&mut self, js_pooling: &JsValue) -> Result<(), JsValue> {
+        let pooling = PoolingWASM::try_from(js_pooling.clone())?;
+        self.0.set_pooling(pooling.into());
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "outputScript")]
+    pub fn set_output_script(&mut self, output_script: &CoreScriptWASM) {
+        self.0.set_output_script(output_script.clone().into())
+    }
+
+    #[wasm_bindgen(setter = "inputs")]
+    pub fn set_inputs(&mut self, js_inputs: &JsValue) -> Result<(), JsValue> {
+        let js_array_inputs = Array::from(js_inputs);
+        let inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = js_array_inputs
+            .iter()
+            .map(|js_input| {
+                let input = js_input
+                    .to_wasm::<InputAddressWASM>("InputAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, (AddressNonce, Credits)), JsValue>((
+                    PlatformAddress::from(input.address),
+                    (input.nonce, input.credits),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, (AddressNonce, Credits)>, JsValue>>()?;
+
+        self.0.set_inputs(inputs);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "output")]
+    pub fn set_output(&mut self, js_output: &JsValue) -> Result<(), JsValue> {
+        let output: Option<(PlatformAddress, Credits)> = match js_output.is_null_or_undefined() {
+            true => None,
+            false => {
+                let converted_output = js_output
+                    .to_wasm::<OutputAddressWASM>("OutputAddressWASM")?
+                    .clone();
+
+                Some((converted_output.address.into(), converted_output.credits))
+            }
+        };
+
+        self.0.set_output(output);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "feeStrategy")]
+    pub fn set_fee_strategy(&mut self, js_fee_strategy: Vec<AddressFundsFeeStrategyStepWASM>) {
+        self.0.set_fee_strategy(
+            js_fee_strategy
+                .iter()
+                .map(|step| step.clone().into())
+                .collect(),
+        )
+    }
+
+    #[wasm_bindgen(setter = "userFeeIncrease")]
+    pub fn set_user_fee_increase(&mut self, user_fee_increase: UserFeeIncrease) {
+        self.0.set_user_fee_increase(user_fee_increase)
+    }
+
+    #[wasm_bindgen(setter = "inputWitness")]
+    pub fn set_input_witness(&mut self, js_input_witnesses: &JsValue) -> Result<(), JsValue> {
+        let js_array_input_witnesses = Array::from(js_input_witnesses);
+        let input_witnesses = js_array_input_witnesses
+            .iter()
+            .map(|js_input| {
+                Ok::<AddressWitness, JsValue>(
+                    js_input
+                        .to_wasm::<AddressWitnessWASM>("AddressWitnessWASM")?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<AddressWitness>, JsValue>>()?;
+
+        self.0.set_witnesses(input_witnesses);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = "fromStateTransition")]
+    pub fn from_state_transition(
+        st: &StateTransitionWASM,
+    ) -> Result<AddressCreditWithdrawalTransitionWASM, JsValue> {
+        let rs_st: StateTransition = st.clone().into();
+
+        match rs_st {
+            StateTransition::AddressCreditWithdrawal(st) => {
+                Ok(AddressCreditWithdrawalTransitionWASM(st))
+            }
+            _ => Err(JsValue::from_str(&"Invalid state transition type)")),
+        }
+    }
+
+    #[wasm_bindgen(js_name = "toStateTransition")]
+    pub fn to_state_transition(&self) -> StateTransitionWASM {
+        StateTransitionWASM::from(StateTransition::from(self.0.clone()))
+    }
+}

--- a/packages/identity_transitions/src/address_transitions/address_funding_from_asset_lock_transition/mod.rs
+++ b/packages/identity_transitions/src/address_transitions/address_funding_from_asset_lock_transition/mod.rs
@@ -1,0 +1,319 @@
+use crate::address_transitions::address_funds_fee_step::AddressFundsFeeStrategyStepWASM;
+use crate::address_transitions::input_address::InputAddressWASM;
+use crate::address_transitions::output_address::OutputAddressWASM;
+use dpp::address_funds::{AddressWitness, PlatformAddress};
+use dpp::fee::Credits;
+use dpp::platform_value::BinaryData;
+use dpp::prelude::{AddressNonce, UserFeeIncrease};
+use dpp::state_transition::address_funding_from_asset_lock_transition::AddressFundingFromAssetLockTransition;
+use dpp::state_transition::address_funding_from_asset_lock_transition::accessors::AddressFundingFromAssetLockTransitionAccessorsV0;
+use dpp::state_transition::address_funding_from_asset_lock_transition::v0::AddressFundingFromAssetLockTransitionV0;
+use dpp::state_transition::{
+    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionLike,
+    StateTransitionSingleSigned, StateTransitionWitnessSigned,
+};
+use js_sys::Array;
+use pshenmic_dpp_asset_lock_proof::AssetLockProofWASM;
+use pshenmic_dpp_platform_address::address_witness::AddressWitnessWASM;
+use pshenmic_dpp_state_transition::StateTransitionWASM;
+use pshenmic_dpp_utils::IntoWasm;
+use std::collections::BTreeMap;
+use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(js_name = "AddressFundingFromAssetLockTransitionWASM")]
+pub struct AddressFundingFromAssetLockTransitionWASM(AddressFundingFromAssetLockTransition);
+
+impl From<AddressFundingFromAssetLockTransitionWASM> for AddressFundingFromAssetLockTransition {
+    fn from(v: AddressFundingFromAssetLockTransitionWASM) -> Self {
+        v.0
+    }
+}
+
+impl From<AddressFundingFromAssetLockTransition> for AddressFundingFromAssetLockTransitionWASM {
+    fn from(v: AddressFundingFromAssetLockTransition) -> Self {
+        AddressFundingFromAssetLockTransitionWASM(v)
+    }
+}
+
+#[wasm_bindgen]
+impl AddressFundingFromAssetLockTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "AddressFundingFromAssetLockTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "AddressFundingFromAssetLockTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        asset_lock_proof: &AssetLockProofWASM,
+        js_inputs: &JsValue,
+        js_fee_strategy: Vec<AddressFundsFeeStrategyStepWASM>,
+        user_fee_increase: UserFeeIncrease,
+        js_input_witnesses: &JsValue,
+        js_outputs: &JsValue,
+    ) -> Result<Self, JsValue> {
+        let js_array_inputs = Array::from(js_inputs);
+        let inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = js_array_inputs
+            .iter()
+            .map(|js_input| {
+                let input = js_input
+                    .to_wasm::<InputAddressWASM>("InputAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, (AddressNonce, Credits)), JsValue>((
+                    PlatformAddress::from(input.address),
+                    (input.nonce, input.credits),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, (AddressNonce, Credits)>, JsValue>>()?;
+
+        let js_array_input_witnesses = Array::from(js_input_witnesses);
+        let input_witnesses = js_array_input_witnesses
+            .iter()
+            .map(|js_input| {
+                Ok::<AddressWitness, JsValue>(
+                    js_input
+                        .to_wasm::<AddressWitnessWASM>("AddressWitnessWASM")?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<AddressWitness>, JsValue>>()?;
+
+        let outputs: BTreeMap<PlatformAddress, Option<Credits>> =
+            match js_outputs.is_null_or_undefined() {
+                true => Err(JsValue::from("outputs must be array"))?,
+                false => {
+                    let js_arr = Array::from(js_outputs);
+
+                    js_arr
+                        .iter()
+                        .map(|js_output| {
+                            let converted_output = js_output
+                                .to_wasm::<OutputAddressWASM>("OutputAddressWASM")?
+                                .clone();
+
+                            let raw_credits = converted_output.credits;
+
+                            let mut credits = None;
+
+                            if raw_credits > 0 {
+                                credits = Some(raw_credits);
+                            }
+
+                            Ok::<(PlatformAddress, Option<Credits>), JsValue>((
+                                converted_output.address.into(),
+                                credits,
+                            ))
+                        })
+                        .collect::<Result<BTreeMap<PlatformAddress, Option<Credits>>, JsValue>>()?
+                }
+            };
+
+        Ok(AddressFundingFromAssetLockTransitionWASM(
+            AddressFundingFromAssetLockTransition::V0(AddressFundingFromAssetLockTransitionV0 {
+                asset_lock_proof: asset_lock_proof.clone().into(),
+                inputs,
+                outputs,
+                fee_strategy: js_fee_strategy
+                    .iter()
+                    .map(|step| step.clone().into())
+                    .collect(),
+                user_fee_increase,
+                input_witnesses,
+                signature: Default::default(),
+            }),
+        ))
+    }
+
+    #[wasm_bindgen(getter = "assetLockProof")]
+    pub fn asset_lock_proof(&self) -> AssetLockProofWASM {
+        AddressFundingFromAssetLockTransitionAccessorsV0::asset_lock_proof(&self.0)
+            .clone()
+            .into()
+    }
+
+    #[wasm_bindgen(getter = "signature")]
+    pub fn signature(&self) -> Vec<u8> {
+        self.0.signature().clone().to_vec()
+    }
+
+    #[wasm_bindgen(getter = "inputs")]
+    pub fn inputs(&self) -> Vec<InputAddressWASM> {
+        self.0
+            .inputs()
+            .iter()
+            .map(|(address, (nonce, credits))| InputAddressWASM {
+                address: address.clone().into(),
+                nonce: nonce.clone(),
+                credits: credits.clone(),
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "outputs")]
+    pub fn outputs(&self) -> Vec<OutputAddressWASM> {
+        self.0
+            .outputs()
+            .iter()
+            .map(|(address, credits)| OutputAddressWASM {
+                address: address.clone().into(),
+                credits: credits.clone().unwrap_or(0),
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "feeStrategy")]
+    pub fn fee_strategy(&self) -> Vec<AddressFundsFeeStrategyStepWASM> {
+        self.0
+            .fee_strategy()
+            .iter()
+            .map(|step| AddressFundsFeeStrategyStepWASM::from(step.clone()))
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "userFeeIncrease")]
+    pub fn user_fee_increase(&self) -> UserFeeIncrease {
+        self.0.user_fee_increase()
+    }
+
+    #[wasm_bindgen(getter = "inputWitness")]
+    pub fn input_witness(&self) -> Vec<AddressWitnessWASM> {
+        self.0
+            .witnesses()
+            .iter()
+            .map(|witness| AddressWitnessWASM::from(witness.clone()))
+            .collect()
+    }
+
+    #[wasm_bindgen(setter = "assetLockProof")]
+    pub fn set_asset_lock_proof(&mut self, asset_lock_proof: &AssetLockProofWASM) {
+        AddressFundingFromAssetLockTransitionAccessorsV0::set_asset_lock_proof(
+            &mut self.0,
+            asset_lock_proof.clone().into(),
+        )
+    }
+
+    #[wasm_bindgen(setter = "signature")]
+    pub fn set_signature(&mut self, sig: Vec<u8>) {
+        self.0.set_signature(BinaryData(sig))
+    }
+
+    #[wasm_bindgen(setter = "inputs")]
+    pub fn set_inputs(&mut self, js_inputs: &JsValue) -> Result<(), JsValue> {
+        let js_array_inputs = Array::from(js_inputs);
+        let inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = js_array_inputs
+            .iter()
+            .map(|js_input| {
+                let input = js_input
+                    .to_wasm::<InputAddressWASM>("InputAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, (AddressNonce, Credits)), JsValue>((
+                    PlatformAddress::from(input.address),
+                    (input.nonce, input.credits),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, (AddressNonce, Credits)>, JsValue>>()?;
+
+        self.0.set_inputs(inputs);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "outputs")]
+    pub fn set_outputs(&mut self, js_outputs: &JsValue) -> Result<(), JsValue> {
+        let outputs: BTreeMap<PlatformAddress, Option<Credits>> =
+            match js_outputs.is_null_or_undefined() {
+                true => Err(JsValue::from("outputs must be array"))?,
+                false => {
+                    let js_arr = Array::from(js_outputs);
+
+                    js_arr
+                        .iter()
+                        .map(|js_output| {
+                            let converted_output = js_output
+                                .to_wasm::<OutputAddressWASM>("OutputAddressWASM")?
+                                .clone();
+
+                            let raw_credits = converted_output.credits;
+
+                            let mut credits = None;
+
+                            if raw_credits > 0 {
+                                credits = Some(raw_credits);
+                            }
+
+                            Ok::<(PlatformAddress, Option<Credits>), JsValue>((
+                                converted_output.address.into(),
+                                credits,
+                            ))
+                        })
+                        .collect::<Result<BTreeMap<PlatformAddress, Option<Credits>>, JsValue>>()?
+                }
+            };
+
+        self.0.set_outputs(outputs);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "feeStrategy")]
+    pub fn set_fee_strategy(&mut self, js_fee_strategy: Vec<AddressFundsFeeStrategyStepWASM>) {
+        self.0.set_fee_strategy(
+            js_fee_strategy
+                .iter()
+                .map(|step| step.clone().into())
+                .collect(),
+        )
+    }
+
+    #[wasm_bindgen(setter = "userFeeIncrease")]
+    pub fn set_user_fee_increase(&mut self, user_fee_increase: UserFeeIncrease) {
+        self.0.set_user_fee_increase(user_fee_increase)
+    }
+
+    #[wasm_bindgen(setter = "inputWitness")]
+    pub fn set_input_witness(&mut self, js_input_witnesses: &JsValue) -> Result<(), JsValue> {
+        let js_array_input_witnesses = Array::from(js_input_witnesses);
+        let input_witnesses = js_array_input_witnesses
+            .iter()
+            .map(|js_input| {
+                Ok::<AddressWitness, JsValue>(
+                    js_input
+                        .to_wasm::<AddressWitnessWASM>("AddressWitnessWASM")?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<AddressWitness>, JsValue>>()?;
+
+        self.0.set_witnesses(input_witnesses);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = "fromStateTransition")]
+    pub fn from_state_transition(
+        st: &StateTransitionWASM,
+    ) -> Result<AddressFundingFromAssetLockTransitionWASM, JsValue> {
+        let rs_st: StateTransition = st.clone().into();
+
+        match rs_st {
+            StateTransition::AddressFundingFromAssetLock(st) => {
+                Ok(AddressFundingFromAssetLockTransitionWASM(st))
+            }
+            _ => Err(JsValue::from_str(&"Invalid state transition type)")),
+        }
+    }
+
+    #[wasm_bindgen(js_name = "toStateTransition")]
+    pub fn to_state_transition(&self) -> StateTransitionWASM {
+        StateTransitionWASM::from(StateTransition::from(self.0.clone()))
+    }
+}

--- a/packages/identity_transitions/src/address_transitions/address_funds_fee_step/mod.rs
+++ b/packages/identity_transitions/src/address_transitions/address_funds_fee_step/mod.rs
@@ -1,0 +1,70 @@
+use dpp::address_funds::AddressFundsFeeStrategyStep;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Clone)]
+#[wasm_bindgen(js_name = "AddressFundsFeeStrategyStepWASM")]
+pub struct AddressFundsFeeStrategyStepWASM(AddressFundsFeeStrategyStep);
+
+impl From<AddressFundsFeeStrategyStepWASM> for AddressFundsFeeStrategyStep {
+    fn from(step: AddressFundsFeeStrategyStepWASM) -> Self {
+        step.0
+    }
+}
+
+impl From<AddressFundsFeeStrategyStep> for AddressFundsFeeStrategyStepWASM {
+    fn from(step: AddressFundsFeeStrategyStep) -> Self {
+        AddressFundsFeeStrategyStepWASM(step)
+    }
+}
+
+#[wasm_bindgen]
+impl AddressFundsFeeStrategyStepWASM {
+    #[wasm_bindgen(getter = "__type")]
+    pub fn type_name(&self) -> String {
+        "AddressFundsFeeStrategyStepWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = "__struct")]
+    pub fn struct_name() -> String {
+        "AddressFundsFeeStrategyStepWASM".to_string()
+    }
+
+    #[wasm_bindgen(js_name = "DeductFromInput")]
+    pub fn deduct_from_input(input: u16) -> AddressFundsFeeStrategyStepWASM {
+        AddressFundsFeeStrategyStepWASM(AddressFundsFeeStrategyStep::DeductFromInput(input))
+    }
+
+    #[wasm_bindgen(js_name = "ReduceOutput")]
+    pub fn reduce_output(output: u16) -> AddressFundsFeeStrategyStepWASM {
+        AddressFundsFeeStrategyStepWASM(AddressFundsFeeStrategyStep::ReduceOutput(output))
+    }
+
+    #[wasm_bindgen(js_name = "getValue")]
+    pub fn get_value(&self) -> u16 {
+        match self.0 {
+            AddressFundsFeeStrategyStep::DeductFromInput(value) => value,
+            AddressFundsFeeStrategyStep::ReduceOutput(value) => value,
+        }
+    }
+
+    #[wasm_bindgen(js_name = "setValue")]
+    pub fn set_value(&mut self, value: u16) {
+        match self.0 {
+            AddressFundsFeeStrategyStep::DeductFromInput(_) => {
+                self.0 = AddressFundsFeeStrategyStep::DeductFromInput(value);
+            }
+            AddressFundsFeeStrategyStep::ReduceOutput(_) => {
+                self.0 = AddressFundsFeeStrategyStep::ReduceOutput(value);
+            }
+        }
+    }
+
+    #[wasm_bindgen(js_name = "getValueType")]
+    pub fn get_value_type(&self) -> String {
+        match self.0 {
+            AddressFundsFeeStrategyStep::DeductFromInput(_) => "DeductFromInput",
+            AddressFundsFeeStrategyStep::ReduceOutput(_) => "ReduceOutput",
+        }
+        .to_string()
+    }
+}

--- a/packages/identity_transitions/src/address_transitions/asset_funds_transfer/mod.rs
+++ b/packages/identity_transitions/src/address_transitions/asset_funds_transfer/mod.rs
@@ -1,0 +1,269 @@
+use crate::address_transitions::address_funds_fee_step::AddressFundsFeeStrategyStepWASM;
+use crate::address_transitions::input_address::InputAddressWASM;
+use crate::address_transitions::output_address::OutputAddressWASM;
+use dpp::address_funds::{AddressWitness, PlatformAddress};
+use dpp::fee::Credits;
+use dpp::prelude::{AddressNonce, UserFeeIncrease};
+use dpp::state_transition::address_funds_transfer_transition::AddressFundsTransferTransition;
+use dpp::state_transition::address_funds_transfer_transition::accessors::AddressFundsTransferTransitionAccessorsV0;
+use dpp::state_transition::address_funds_transfer_transition::v0::AddressFundsTransferTransitionV0;
+use dpp::state_transition::{
+    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionLike,
+    StateTransitionWitnessSigned,
+};
+use js_sys::Array;
+use pshenmic_dpp_platform_address::address_witness::AddressWitnessWASM;
+use pshenmic_dpp_state_transition::StateTransitionWASM;
+use pshenmic_dpp_utils::IntoWasm;
+use std::collections::BTreeMap;
+use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(js_name = "AddressFundsTransferTransitionWASM")]
+pub struct AddressFundsTransferTransitionWASM(AddressFundsTransferTransition);
+
+impl From<AddressFundsTransferTransitionWASM> for AddressFundsTransferTransition {
+    fn from(v: AddressFundsTransferTransitionWASM) -> Self {
+        v.0
+    }
+}
+
+impl From<AddressFundsTransferTransition> for AddressFundsTransferTransitionWASM {
+    fn from(v: AddressFundsTransferTransition) -> Self {
+        Self(v)
+    }
+}
+
+#[wasm_bindgen]
+impl AddressFundsTransferTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "AssetFundsTransferTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "AssetFundsTransferTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        js_inputs: &JsValue,
+        js_fee_strategy: Vec<AddressFundsFeeStrategyStepWASM>,
+        user_fee_increase: UserFeeIncrease,
+        js_input_witnesses: &JsValue,
+        js_outputs: &JsValue,
+    ) -> Result<Self, JsValue> {
+        let js_array_inputs = Array::from(js_inputs);
+        let inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = js_array_inputs
+            .iter()
+            .map(|js_input| {
+                let input = js_input
+                    .to_wasm::<InputAddressWASM>("InputAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, (AddressNonce, Credits)), JsValue>((
+                    PlatformAddress::from(input.address),
+                    (input.nonce, input.credits),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, (AddressNonce, Credits)>, JsValue>>()?;
+
+        let js_array_input_witnesses = Array::from(js_input_witnesses);
+        let input_witnesses = js_array_input_witnesses
+            .iter()
+            .map(|js_input| {
+                Ok::<AddressWitness, JsValue>(
+                    js_input
+                        .to_wasm::<AddressWitnessWASM>("AddressWitnessWASM")?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<AddressWitness>, JsValue>>()?;
+
+        let outputs: BTreeMap<PlatformAddress, Credits> = match js_outputs.is_null_or_undefined() {
+            true => Err(JsValue::from("outputs must be array"))?,
+            false => {
+                let js_arr = Array::from(js_outputs);
+
+                js_arr
+                    .iter()
+                    .map(|js_output| {
+                        let converted_output = js_output
+                            .to_wasm::<OutputAddressWASM>("OutputAddressWASM")?
+                            .clone();
+
+                        Ok::<(PlatformAddress, Credits), JsValue>((
+                            converted_output.address.into(),
+                            converted_output.credits,
+                        ))
+                    })
+                    .collect::<Result<BTreeMap<PlatformAddress, Credits>, JsValue>>()?
+            }
+        };
+
+        Ok(AddressFundsTransferTransitionWASM(
+            AddressFundsTransferTransition::V0(AddressFundsTransferTransitionV0 {
+                inputs,
+                outputs,
+                fee_strategy: js_fee_strategy
+                    .iter()
+                    .map(|step| step.clone().into())
+                    .collect(),
+                user_fee_increase,
+                input_witnesses,
+            }),
+        ))
+    }
+
+    #[wasm_bindgen(getter = "inputs")]
+    pub fn inputs(&self) -> Vec<InputAddressWASM> {
+        self.0
+            .inputs()
+            .iter()
+            .map(|(address, (nonce, credits))| InputAddressWASM {
+                address: address.clone().into(),
+                nonce: nonce.clone(),
+                credits: credits.clone(),
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "outputs")]
+    pub fn outputs(&self) -> Vec<OutputAddressWASM> {
+        self.0
+            .outputs()
+            .iter()
+            .map(|(address, credits)| OutputAddressWASM {
+                address: address.clone().into(),
+                credits: credits.clone(),
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "feeStrategy")]
+    pub fn fee_strategy(&self) -> Vec<AddressFundsFeeStrategyStepWASM> {
+        self.0
+            .fee_strategy()
+            .iter()
+            .map(|step| AddressFundsFeeStrategyStepWASM::from(step.clone()))
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "userFeeIncrease")]
+    pub fn user_fee_increase(&self) -> UserFeeIncrease {
+        self.0.user_fee_increase()
+    }
+
+    #[wasm_bindgen(getter = "inputWitness")]
+    pub fn input_witness(&self) -> Vec<AddressWitnessWASM> {
+        self.0
+            .witnesses()
+            .iter()
+            .map(|witness| AddressWitnessWASM::from(witness.clone()))
+            .collect()
+    }
+
+    #[wasm_bindgen(setter = "inputs")]
+    pub fn set_inputs(&mut self, js_inputs: &JsValue) -> Result<(), JsValue> {
+        let js_array_inputs = Array::from(js_inputs);
+        let inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = js_array_inputs
+            .iter()
+            .map(|js_input| {
+                let input = js_input
+                    .to_wasm::<InputAddressWASM>("InputAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, (AddressNonce, Credits)), JsValue>((
+                    PlatformAddress::from(input.address),
+                    (input.nonce, input.credits),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, (AddressNonce, Credits)>, JsValue>>()?;
+
+        self.0.set_inputs(inputs);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "outputs")]
+    pub fn set_outputs(&mut self, js_outputs: &JsValue) -> Result<(), JsValue> {
+        let outputs: BTreeMap<PlatformAddress, Credits> = match js_outputs.is_null_or_undefined() {
+            true => Err(JsValue::from("outputs must be array"))?,
+            false => {
+                let js_arr = Array::from(js_outputs);
+
+                js_arr
+                    .iter()
+                    .map(|js_output| {
+                        let converted_output = js_output
+                            .to_wasm::<OutputAddressWASM>("OutputAddressWASM")?
+                            .clone();
+
+                        Ok::<(PlatformAddress, Credits), JsValue>((
+                            converted_output.address.into(),
+                            converted_output.credits,
+                        ))
+                    })
+                    .collect::<Result<BTreeMap<PlatformAddress, Credits>, JsValue>>()?
+            }
+        };
+
+        self.0.set_outputs(outputs);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "feeStrategy")]
+    pub fn set_fee_strategy(&mut self, js_fee_strategy: Vec<AddressFundsFeeStrategyStepWASM>) {
+        self.0.set_fee_strategy(
+            js_fee_strategy
+                .iter()
+                .map(|step| step.clone().into())
+                .collect(),
+        )
+    }
+
+    #[wasm_bindgen(setter = "userFeeIncrease")]
+    pub fn set_user_fee_increase(&mut self, user_fee_increase: UserFeeIncrease) {
+        self.0.set_user_fee_increase(user_fee_increase)
+    }
+
+    #[wasm_bindgen(setter = "inputWitness")]
+    pub fn set_input_witness(&mut self, js_input_witnesses: &JsValue) -> Result<(), JsValue> {
+        let js_array_input_witnesses = Array::from(js_input_witnesses);
+        let input_witnesses = js_array_input_witnesses
+            .iter()
+            .map(|js_input| {
+                Ok::<AddressWitness, JsValue>(
+                    js_input
+                        .to_wasm::<AddressWitnessWASM>("AddressWitnessWASM")?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<AddressWitness>, JsValue>>()?;
+
+        self.0.set_witnesses(input_witnesses);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = "fromStateTransition")]
+    pub fn from_state_transition(
+        st: &StateTransitionWASM,
+    ) -> Result<AddressFundsTransferTransitionWASM, JsValue> {
+        let rs_st: StateTransition = st.clone().into();
+
+        match rs_st {
+            StateTransition::AddressFundsTransfer(st) => Ok(AddressFundsTransferTransitionWASM(st)),
+            _ => Err(JsValue::from_str(&"Invalid state transition type)")),
+        }
+    }
+
+    #[wasm_bindgen(js_name = "toStateTransition")]
+    pub fn to_state_transition(&self) -> StateTransitionWASM {
+        StateTransitionWASM::from(StateTransition::from(self.0.clone()))
+    }
+}

--- a/packages/identity_transitions/src/address_transitions/create_from_address_transition/mod.rs
+++ b/packages/identity_transitions/src/address_transitions/create_from_address_transition/mod.rs
@@ -1,0 +1,300 @@
+use crate::address_transitions::address_funds_fee_step::AddressFundsFeeStrategyStepWASM;
+use crate::address_transitions::input_address::InputAddressWASM;
+use crate::address_transitions::output_address::OutputAddressWASM;
+use dpp::address_funds::{AddressWitness, PlatformAddress};
+use dpp::fee::Credits;
+use dpp::prelude::{AddressNonce, UserFeeIncrease};
+use dpp::state_transition::identity_create_from_addresses_transition::IdentityCreateFromAddressesTransition;
+use dpp::state_transition::identity_create_from_addresses_transition::accessors::IdentityCreateFromAddressesTransitionAccessorsV0;
+use dpp::state_transition::identity_create_from_addresses_transition::v0::IdentityCreateFromAddressesTransitionV0;
+use dpp::state_transition::public_key_in_creation::IdentityPublicKeyInCreation;
+use dpp::state_transition::{
+    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionLike,
+    StateTransitionWitnessSigned,
+};
+use js_sys::Array;
+use pshenmic_dpp_identity_public_key::public_key_in_creation::IdentityPublicKeyInCreationWASM;
+use pshenmic_dpp_platform_address::address_witness::AddressWitnessWASM;
+use pshenmic_dpp_state_transition::StateTransitionWASM;
+use pshenmic_dpp_utils::IntoWasm;
+use std::collections::BTreeMap;
+use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(js_name = "IdentityCreateFromAddressesTransitionWASM")]
+pub struct IdentityCreateFromAddressesTransitionWASM(IdentityCreateFromAddressesTransition);
+
+impl From<IdentityCreateFromAddressesTransition> for IdentityCreateFromAddressesTransitionWASM {
+    fn from(val: IdentityCreateFromAddressesTransition) -> Self {
+        Self(val)
+    }
+}
+
+impl From<IdentityCreateFromAddressesTransitionWASM> for IdentityCreateFromAddressesTransition {
+    fn from(val: IdentityCreateFromAddressesTransitionWASM) -> Self {
+        val.0
+    }
+}
+
+#[wasm_bindgen]
+impl IdentityCreateFromAddressesTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityCreateFromAddressesTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "IdentityCreateFromAddressesTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        js_identity_public_key_in_creation: &JsValue,
+        js_inputs: &JsValue,
+        js_fee_strategy: Vec<AddressFundsFeeStrategyStepWASM>,
+        user_fee_increase: UserFeeIncrease,
+        js_input_witnesses: &JsValue,
+        js_output: &JsValue,
+    ) -> Result<IdentityCreateFromAddressesTransitionWASM, JsValue> {
+        let js_array_public_key_in_creation = Array::from(js_identity_public_key_in_creation);
+        let public_keys: Vec<IdentityPublicKeyInCreation> = js_array_public_key_in_creation
+            .iter()
+            .map(|js_key| {
+                Ok::<IdentityPublicKeyInCreation, JsValue>(
+                    js_key
+                        .to_wasm::<IdentityPublicKeyInCreationWASM>(
+                            "IdentityPublicKeyInCreationWASM",
+                        )?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<IdentityPublicKeyInCreation>, JsValue>>()?;
+
+        let js_array_inputs = Array::from(js_inputs);
+        let inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = js_array_inputs
+            .iter()
+            .map(|js_input| {
+                let input = js_input
+                    .to_wasm::<InputAddressWASM>("InputAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, (AddressNonce, Credits)), JsValue>((
+                    PlatformAddress::from(input.address),
+                    (input.nonce, input.credits),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, (AddressNonce, Credits)>, JsValue>>()?;
+
+        let js_array_input_witnesses = Array::from(js_input_witnesses);
+        let input_witnesses = js_array_input_witnesses
+            .iter()
+            .map(|js_input| {
+                Ok::<AddressWitness, JsValue>(
+                    js_input
+                        .to_wasm::<AddressWitnessWASM>("AddressWitnessWASM")?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<AddressWitness>, JsValue>>()?;
+
+        let output: Option<(PlatformAddress, Credits)> = match js_output.is_null_or_undefined() {
+            true => None,
+            false => {
+                let converted_output = js_output
+                    .to_wasm::<OutputAddressWASM>("OutputAddressWASM")?
+                    .clone();
+
+                Some((converted_output.address.into(), converted_output.credits))
+            }
+        };
+
+        Ok(IdentityCreateFromAddressesTransitionWASM(
+            IdentityCreateFromAddressesTransition::V0(IdentityCreateFromAddressesTransitionV0 {
+                public_keys,
+                inputs,
+                output,
+                fee_strategy: js_fee_strategy
+                    .iter()
+                    .map(|step| step.clone().into())
+                    .collect(),
+                user_fee_increase,
+                input_witnesses,
+            }),
+        ))
+    }
+
+    #[wasm_bindgen(getter = "publicKeys")]
+    pub fn public_keys(&self) -> Vec<IdentityPublicKeyInCreationWASM> {
+        self.0
+            .public_keys()
+            .iter()
+            .map(|key| key.clone().into())
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "inputs")]
+    pub fn inputs(&self) -> Vec<InputAddressWASM> {
+        self.0
+            .inputs()
+            .iter()
+            .map(|(address, (nonce, credits))| InputAddressWASM {
+                address: address.clone().into(),
+                nonce: nonce.clone(),
+                credits: credits.clone(),
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "output")]
+    pub fn output(&self) -> Option<OutputAddressWASM> {
+        self.0.output().map(|(address, credits)| OutputAddressWASM {
+            address: address.clone().into(),
+            credits: credits.clone(),
+        })
+    }
+
+    #[wasm_bindgen(getter = "feeStrategy")]
+    pub fn fee_strategy(&self) -> Vec<AddressFundsFeeStrategyStepWASM> {
+        self.0
+            .fee_strategy()
+            .iter()
+            .map(|step| AddressFundsFeeStrategyStepWASM::from(step.clone()))
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "userFeeIncrease")]
+    pub fn user_fee_increase(&self) -> UserFeeIncrease {
+        self.0.user_fee_increase()
+    }
+
+    #[wasm_bindgen(getter = "inputWitness")]
+    pub fn input_witness(&self) -> Vec<AddressWitnessWASM> {
+        self.0
+            .witnesses()
+            .iter()
+            .map(|witness| AddressWitnessWASM::from(witness.clone()))
+            .collect()
+    }
+
+    #[wasm_bindgen(setter = "publicKeys")]
+    pub fn set_public_keys(
+        &mut self,
+        js_identity_public_key_in_creation: &JsValue,
+    ) -> Result<(), JsValue> {
+        let js_array_public_key_in_creation = Array::from(js_identity_public_key_in_creation);
+        let public_keys: Vec<IdentityPublicKeyInCreation> = js_array_public_key_in_creation
+            .iter()
+            .map(|js_key| {
+                Ok::<IdentityPublicKeyInCreation, JsValue>(
+                    js_key
+                        .to_wasm::<IdentityPublicKeyInCreationWASM>(
+                            "IdentityPublicKeyInCreationWASM",
+                        )?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<IdentityPublicKeyInCreation>, JsValue>>()?;
+
+        self.0.set_public_keys(public_keys);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "inputs")]
+    pub fn set_inputs(&mut self, js_inputs: &JsValue) -> Result<(), JsValue> {
+        let js_array_inputs = Array::from(js_inputs);
+        let inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = js_array_inputs
+            .iter()
+            .map(|js_input| {
+                let input = js_input
+                    .to_wasm::<InputAddressWASM>("InputAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, (AddressNonce, Credits)), JsValue>((
+                    PlatformAddress::from(input.address),
+                    (input.nonce, input.credits),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, (AddressNonce, Credits)>, JsValue>>()?;
+
+        self.0.set_inputs(inputs);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "output")]
+    pub fn set_output(&mut self, js_output: &JsValue) -> Result<(), JsValue> {
+        let output: Option<(PlatformAddress, Credits)> = match js_output.is_null_or_undefined() {
+            true => None,
+            false => {
+                let converted_output = js_output
+                    .to_wasm::<OutputAddressWASM>("OutputAddressWASM")?
+                    .clone();
+
+                Some((converted_output.address.into(), converted_output.credits))
+            }
+        };
+
+        self.0.set_output(output);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "feeStrategy")]
+    pub fn set_fee_strategy(&mut self, js_fee_strategy: Vec<AddressFundsFeeStrategyStepWASM>) {
+        self.0.set_fee_strategy(
+            js_fee_strategy
+                .iter()
+                .map(|step| step.clone().into())
+                .collect(),
+        )
+    }
+
+    #[wasm_bindgen(setter = "userFeeIncrease")]
+    pub fn set_user_fee_increase(&mut self, user_fee_increase: UserFeeIncrease) {
+        self.0.set_user_fee_increase(user_fee_increase)
+    }
+
+    #[wasm_bindgen(setter = "inputWitness")]
+    pub fn set_input_witness(&mut self, js_input_witnesses: &JsValue) -> Result<(), JsValue> {
+        let js_array_input_witnesses = Array::from(js_input_witnesses);
+        let input_witnesses = js_array_input_witnesses
+            .iter()
+            .map(|js_input| {
+                Ok::<AddressWitness, JsValue>(
+                    js_input
+                        .to_wasm::<AddressWitnessWASM>("AddressWitnessWASM")?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<AddressWitness>, JsValue>>()?;
+
+        self.0.set_witnesses(input_witnesses);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = "fromStateTransition")]
+    pub fn from_state_transition(
+        st: &StateTransitionWASM,
+    ) -> Result<IdentityCreateFromAddressesTransitionWASM, JsValue> {
+        let rs_st: StateTransition = st.clone().into();
+
+        match rs_st {
+            StateTransition::IdentityCreateFromAddresses(st) => {
+                Ok(IdentityCreateFromAddressesTransitionWASM(st))
+            }
+            _ => Err(JsValue::from_str(&"Invalid state transition type)")),
+        }
+    }
+
+    #[wasm_bindgen(js_name = "toStateTransition")]
+    pub fn to_state_transition(&self) -> StateTransitionWASM {
+        StateTransitionWASM::from(StateTransition::from(self.0.clone()))
+    }
+}

--- a/packages/identity_transitions/src/address_transitions/identity_credit_transfer_to_addresses_transition/mod.rs
+++ b/packages/identity_transitions/src/address_transitions/identity_credit_transfer_to_addresses_transition/mod.rs
@@ -1,0 +1,218 @@
+use dpp::address_funds::PlatformAddress;
+use dpp::fee::Credits;
+use dpp::identity::KeyID;
+use dpp::prelude::{IdentityNonce, UserFeeIncrease};
+use dpp::state_transition::identity_credit_transfer_to_addresses_transition::IdentityCreditTransferToAddressesTransition;
+use dpp::state_transition::identity_credit_transfer_to_addresses_transition::accessors::IdentityCreditTransferToAddressesTransitionAccessorsV0;
+use dpp::state_transition::identity_credit_transfer_to_addresses_transition::v0::IdentityCreditTransferToAddressesTransitionV0;
+use dpp::state_transition::{
+    StateTransition, StateTransitionIdentitySigned, StateTransitionLike,
+    StateTransitionSingleSigned,
+};
+use js_sys::Array;
+use pshenmic_dpp_identifier::IdentifierWASM;
+use pshenmic_dpp_platform_address::PlatformAddressWASM;
+use pshenmic_dpp_state_transition::StateTransitionWASM;
+use pshenmic_dpp_utils::IntoWasm;
+use std::collections::BTreeMap;
+use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Clone)]
+#[wasm_bindgen(js_name = "RecipientAddressWASM")]
+pub struct RecipientAddressWASM {
+    #[wasm_bindgen(getter_with_clone)]
+    pub address: PlatformAddressWASM,
+    pub amount: Credits,
+}
+
+#[wasm_bindgen]
+impl RecipientAddressWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "RecipientAddressWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "RecipientAddressWASM".to_string()
+    }
+}
+
+#[wasm_bindgen(js_name = "IdentityCreditTransferToAddressesTransitionWASM")]
+pub struct IdentityCreditTransferToAddressesTransitionWASM(
+    IdentityCreditTransferToAddressesTransition,
+);
+
+impl From<IdentityCreditTransferToAddressesTransitionWASM>
+    for IdentityCreditTransferToAddressesTransition
+{
+    fn from(t: IdentityCreditTransferToAddressesTransitionWASM) -> Self {
+        t.0
+    }
+}
+
+impl From<IdentityCreditTransferToAddressesTransition>
+    for IdentityCreditTransferToAddressesTransitionWASM
+{
+    fn from(value: IdentityCreditTransferToAddressesTransition) -> Self {
+        IdentityCreditTransferToAddressesTransitionWASM(value)
+    }
+}
+
+#[wasm_bindgen]
+impl IdentityCreditTransferToAddressesTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityCreditTransferToAddressesTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "IdentityCreditTransferToAddressesTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        js_identifier: &JsValue,
+        js_addresses: &JsValue,
+        nonce: IdentityNonce,
+        user_fee_increase: UserFeeIncrease,
+    ) -> Result<Self, JsValue> {
+        let identifier = IdentifierWASM::try_from(js_identifier)?;
+
+        let addresses_array = Array::from(js_addresses);
+
+        let addresses: BTreeMap<PlatformAddress, Credits> = addresses_array
+            .iter()
+            .map(|js_address| {
+                let address = js_address
+                    .to_wasm::<RecipientAddressWASM>("RecipientAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, u64), JsValue>((
+                    address.address.into(),
+                    address.amount.clone(),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, Credits>, JsValue>>()?;
+
+        Ok(IdentityCreditTransferToAddressesTransitionWASM(
+            IdentityCreditTransferToAddressesTransition::V0(
+                IdentityCreditTransferToAddressesTransitionV0 {
+                    identity_id: identifier.into(),
+                    recipient_addresses: addresses,
+                    nonce,
+                    user_fee_increase,
+                    signature_public_key_id: 0,
+                    signature: Default::default(),
+                },
+            ),
+        ))
+    }
+
+    #[wasm_bindgen(getter = "identityId")]
+    pub fn identity_id(&self) -> IdentifierWASM {
+        self.0.identity_id().into()
+    }
+
+    #[wasm_bindgen(getter = "recipientAddresses")]
+    pub fn recipient_addresses(&self) -> Vec<RecipientAddressWASM> {
+        let rs_addresses = self.0.recipient_addresses();
+
+        rs_addresses
+            .iter()
+            .map(|(address, credits)| RecipientAddressWASM {
+                address: address.clone().into(),
+                amount: credits.clone(),
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "nonce")]
+    pub fn nonce(&self) -> IdentityNonce {
+        self.0.nonce()
+    }
+
+    #[wasm_bindgen(getter = "userFeeIncrease")]
+    pub fn user_fee_increase(&self) -> UserFeeIncrease {
+        self.0.user_fee_increase()
+    }
+
+    #[wasm_bindgen(getter = "signaturePublicKeyId")]
+    pub fn signature_public_key_id(&self) -> KeyID {
+        self.0.signature_public_key_id()
+    }
+
+    #[wasm_bindgen(getter = "signature")]
+    pub fn signature(&self) -> Vec<u8> {
+        self.0.signature().to_vec()
+    }
+
+    #[wasm_bindgen(setter = "identityId")]
+    pub fn set_identity_id(&mut self, js_identity_id: &JsValue) -> Result<(), JsValue> {
+        let identity_id = IdentifierWASM::try_from(js_identity_id)?;
+
+        Ok(self.0.set_identity_id(identity_id.into()))
+    }
+
+    #[wasm_bindgen(setter = "recipientAddresses")]
+    pub fn set_recipient_addresses(&mut self, js_addresses: &JsValue) -> Result<(), JsValue> {
+        let addresses_array = Array::from(js_addresses);
+
+        let addresses: BTreeMap<PlatformAddress, Credits> = addresses_array
+            .iter()
+            .map(|js_address| {
+                let address = js_address
+                    .to_wasm::<RecipientAddressWASM>("RecipientAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, u64), JsValue>((
+                    address.address.into(),
+                    address.amount.clone(),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, Credits>, JsValue>>()?;
+
+        Ok(self.0.set_recipient_addresses(addresses))
+    }
+
+    #[wasm_bindgen(setter = "nonce")]
+    pub fn set_nonce(&mut self, nonce: IdentityNonce) {
+        self.0.set_nonce(nonce)
+    }
+
+    #[wasm_bindgen(setter = "userFeeIncrease")]
+    pub fn set_user_fee_increase(&mut self, user_fee_increase: UserFeeIncrease) {
+        self.0.set_user_fee_increase(user_fee_increase)
+    }
+
+    #[wasm_bindgen(setter = "signaturePublicKeyId")]
+    pub fn set_signature_public_key_id(&mut self, key_id: KeyID) {
+        self.0.set_signature_public_key_id(key_id)
+    }
+
+    #[wasm_bindgen(setter = "signature")]
+    pub fn set_signature(&mut self, signature: Vec<u8>) {
+        self.0.set_signature_bytes(signature)
+    }
+
+    #[wasm_bindgen(js_name = "fromStateTransition")]
+    pub fn from_state_transition(
+        st: &StateTransitionWASM,
+    ) -> Result<IdentityCreditTransferToAddressesTransitionWASM, JsValue> {
+        let rs_st: StateTransition = st.clone().into();
+
+        match rs_st {
+            StateTransition::IdentityCreditTransferToAddresses(st) => {
+                Ok(IdentityCreditTransferToAddressesTransitionWASM(st))
+            }
+            _ => Err(JsValue::from_str(&"Invalid state transition type)")),
+        }
+    }
+
+    #[wasm_bindgen(js_name = "toStateTransition")]
+    pub fn to_state_transition(&self) -> StateTransitionWASM {
+        StateTransitionWASM::from(StateTransition::from(self.0.clone()))
+    }
+}

--- a/packages/identity_transitions/src/address_transitions/input_address/mod.rs
+++ b/packages/identity_transitions/src/address_transitions/input_address/mod.rs
@@ -1,0 +1,64 @@
+use dpp::fee::Credits;
+use dpp::prelude::AddressNonce;
+use pshenmic_dpp_platform_address::PlatformAddressWASM;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Clone)]
+#[wasm_bindgen(js_name = "InputAddressWASM")]
+pub struct InputAddressWASM {
+    pub(crate) address: PlatformAddressWASM,
+    pub(crate) nonce: AddressNonce,
+    pub(crate) credits: Credits,
+}
+
+#[wasm_bindgen]
+impl InputAddressWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "InputAddressWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "InputAddressWASM".to_string()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(address: &PlatformAddressWASM, nonce: AddressNonce, credits: Credits) -> Self {
+        InputAddressWASM {
+            address: address.clone(),
+            nonce,
+            credits,
+        }
+    }
+
+    #[wasm_bindgen(getter=address)]
+    pub fn address(&self) -> PlatformAddressWASM {
+        self.address.clone()
+    }
+
+    #[wasm_bindgen(getter=nonce)]
+    pub fn nonce(&self) -> AddressNonce {
+        self.nonce
+    }
+
+    #[wasm_bindgen(getter=credits)]
+    pub fn credits(&self) -> Credits {
+        self.credits
+    }
+
+    #[wasm_bindgen(setter=address)]
+    pub fn set_address(&mut self, address: &PlatformAddressWASM) {
+        self.address = address.clone()
+    }
+
+    #[wasm_bindgen(setter=nonce)]
+    pub fn set_nonce(&mut self, nonce: AddressNonce) {
+        self.nonce = nonce
+    }
+
+    #[wasm_bindgen(setter=credits)]
+    pub fn set_credits(&mut self, credits: Credits) {
+        self.credits = credits
+    }
+}

--- a/packages/identity_transitions/src/address_transitions/mod.rs
+++ b/packages/identity_transitions/src/address_transitions/mod.rs
@@ -1,0 +1,9 @@
+pub mod address_credit_withdrawal_transition;
+pub mod address_funding_from_asset_lock_transition;
+pub mod address_funds_fee_step;
+pub mod asset_funds_transfer;
+pub mod create_from_address_transition;
+pub mod identity_credit_transfer_to_addresses_transition;
+pub mod input_address;
+pub mod output_address;
+pub mod top_up_from_address;

--- a/packages/identity_transitions/src/address_transitions/output_address/mod.rs
+++ b/packages/identity_transitions/src/address_transitions/output_address/mod.rs
@@ -1,0 +1,48 @@
+use dpp::fee::Credits;
+use pshenmic_dpp_platform_address::PlatformAddressWASM;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Clone)]
+#[wasm_bindgen(js_name = "OutputAddressWASM")]
+pub struct OutputAddressWASM {
+    pub(crate) address: PlatformAddressWASM,
+    pub(crate) credits: Credits,
+}
+
+#[wasm_bindgen]
+impl OutputAddressWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "OutputAddressWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "OutputAddressWASM".to_string()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(address: PlatformAddressWASM, credits: Credits) -> Self {
+        OutputAddressWASM { address, credits }
+    }
+
+    #[wasm_bindgen(getter=address)]
+    pub fn address(&self) -> PlatformAddressWASM {
+        self.address.clone()
+    }
+
+    #[wasm_bindgen(getter=credits)]
+    pub fn credits(&self) -> Credits {
+        self.credits
+    }
+
+    #[wasm_bindgen(setter=address)]
+    pub fn set_address(&mut self, address: &PlatformAddressWASM) {
+        self.address = address.clone()
+    }
+
+    #[wasm_bindgen(setter=credits)]
+    pub fn set_credits(&mut self, credits: Credits) {
+        self.credits = credits
+    }
+}

--- a/packages/identity_transitions/src/address_transitions/top_up_from_address/mod.rs
+++ b/packages/identity_transitions/src/address_transitions/top_up_from_address/mod.rs
@@ -1,0 +1,253 @@
+use crate::address_transitions::address_funds_fee_step::AddressFundsFeeStrategyStepWASM;
+use crate::address_transitions::input_address::InputAddressWASM;
+use crate::address_transitions::output_address::OutputAddressWASM;
+use dpp::address_funds::{AddressWitness, PlatformAddress};
+use dpp::fee::Credits;
+use dpp::prelude::{AddressNonce, UserFeeIncrease};
+use dpp::state_transition::identity_topup_from_addresses_transition::IdentityTopUpFromAddressesTransition;
+use dpp::state_transition::identity_topup_from_addresses_transition::accessors::IdentityTopUpFromAddressesTransitionAccessorsV0;
+use dpp::state_transition::identity_topup_from_addresses_transition::v0::IdentityTopUpFromAddressesTransitionV0;
+use dpp::state_transition::{
+    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionLike,
+    StateTransitionWitnessSigned,
+};
+use js_sys::Array;
+use pshenmic_dpp_identifier::IdentifierWASM;
+use pshenmic_dpp_platform_address::address_witness::AddressWitnessWASM;
+use pshenmic_dpp_state_transition::StateTransitionWASM;
+use pshenmic_dpp_utils::IntoWasm;
+use std::collections::BTreeMap;
+use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Clone)]
+#[wasm_bindgen(js_name = "IdentityTopUpFromAddressesTransitionWASM")]
+pub struct IdentityTopUpFromAddressesTransitionWASM(IdentityTopUpFromAddressesTransition);
+
+impl From<IdentityTopUpFromAddressesTransitionWASM> for IdentityTopUpFromAddressesTransition {
+    fn from(val: IdentityTopUpFromAddressesTransitionWASM) -> Self {
+        val.0
+    }
+}
+
+impl From<IdentityTopUpFromAddressesTransition> for IdentityTopUpFromAddressesTransitionWASM {
+    fn from(val: IdentityTopUpFromAddressesTransition) -> Self {
+        IdentityTopUpFromAddressesTransitionWASM(val)
+    }
+}
+
+#[wasm_bindgen]
+impl IdentityTopUpFromAddressesTransitionWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "IdentityTopUpFromAddressesTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "IdentityTopUpFromAddressesTransitionWASM".to_string()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        js_identifier: &JsValue,
+        js_inputs: &JsValue,
+        js_fee_strategy: Vec<AddressFundsFeeStrategyStepWASM>,
+        user_fee_increase: UserFeeIncrease,
+        js_input_witnesses: &JsValue,
+        js_output: &JsValue,
+    ) -> Result<Self, JsValue> {
+        let identifier = IdentifierWASM::try_from(js_identifier)?;
+
+        let js_array_inputs = Array::from(js_inputs);
+        let inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = js_array_inputs
+            .iter()
+            .map(|js_input| {
+                let input = js_input
+                    .to_wasm::<InputAddressWASM>("InputAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, (AddressNonce, Credits)), JsValue>((
+                    PlatformAddress::from(input.address),
+                    (input.nonce, input.credits),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, (AddressNonce, Credits)>, JsValue>>()?;
+
+        let js_array_input_witnesses = Array::from(js_input_witnesses);
+        let input_witnesses = js_array_input_witnesses
+            .iter()
+            .map(|js_input| {
+                Ok::<AddressWitness, JsValue>(
+                    js_input
+                        .to_wasm::<AddressWitnessWASM>("AddressWitnessWASM")?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<AddressWitness>, JsValue>>()?;
+
+        let output: Option<(PlatformAddress, Credits)> = match js_output.is_null_or_undefined() {
+            true => None,
+            false => {
+                let converted_output = js_output
+                    .to_wasm::<OutputAddressWASM>("OutputAddressWASM")?
+                    .clone();
+
+                Some((converted_output.address.into(), converted_output.credits))
+            }
+        };
+
+        Ok(IdentityTopUpFromAddressesTransitionWASM(
+            IdentityTopUpFromAddressesTransition::V0(IdentityTopUpFromAddressesTransitionV0 {
+                inputs,
+                output,
+                identity_id: identifier.into(),
+                fee_strategy: js_fee_strategy
+                    .iter()
+                    .map(|step| step.clone().into())
+                    .collect(),
+                user_fee_increase,
+                input_witnesses,
+            }),
+        ))
+    }
+
+    #[wasm_bindgen(getter = "inputs")]
+    pub fn inputs(&self) -> Vec<InputAddressWASM> {
+        self.0
+            .inputs()
+            .iter()
+            .map(|(address, (nonce, credits))| InputAddressWASM {
+                address: address.clone().into(),
+                nonce: nonce.clone(),
+                credits: credits.clone(),
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "output")]
+    pub fn output(&self) -> Option<OutputAddressWASM> {
+        self.0.output().map(|(address, credits)| OutputAddressWASM {
+            address: address.clone().into(),
+            credits: credits.clone(),
+        })
+    }
+
+    #[wasm_bindgen(getter = "feeStrategy")]
+    pub fn fee_strategy(&self) -> Vec<AddressFundsFeeStrategyStepWASM> {
+        self.0
+            .fee_strategy()
+            .iter()
+            .map(|step| AddressFundsFeeStrategyStepWASM::from(step.clone()))
+            .collect()
+    }
+
+    #[wasm_bindgen(getter = "userFeeIncrease")]
+    pub fn user_fee_increase(&self) -> UserFeeIncrease {
+        self.0.user_fee_increase()
+    }
+
+    #[wasm_bindgen(getter = "inputWitness")]
+    pub fn input_witness(&self) -> Vec<AddressWitnessWASM> {
+        self.0
+            .witnesses()
+            .iter()
+            .map(|witness| AddressWitnessWASM::from(witness.clone()))
+            .collect()
+    }
+
+    #[wasm_bindgen(setter = "inputs")]
+    pub fn set_inputs(&mut self, js_inputs: &JsValue) -> Result<(), JsValue> {
+        let js_array_inputs = Array::from(js_inputs);
+        let inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = js_array_inputs
+            .iter()
+            .map(|js_input| {
+                let input = js_input
+                    .to_wasm::<InputAddressWASM>("InputAddressWASM")?
+                    .clone();
+
+                Ok::<(PlatformAddress, (AddressNonce, Credits)), JsValue>((
+                    PlatformAddress::from(input.address),
+                    (input.nonce, input.credits),
+                ))
+            })
+            .collect::<Result<BTreeMap<PlatformAddress, (AddressNonce, Credits)>, JsValue>>()?;
+
+        self.0.set_inputs(inputs);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "output")]
+    pub fn set_output(&mut self, js_output: &JsValue) -> Result<(), JsValue> {
+        let output: Option<(PlatformAddress, Credits)> = match js_output.is_null_or_undefined() {
+            true => None,
+            false => {
+                let converted_output = js_output
+                    .to_wasm::<OutputAddressWASM>("OutputAddressWASM")?
+                    .clone();
+
+                Some((converted_output.address.into(), converted_output.credits))
+            }
+        };
+
+        self.0.set_output(output);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(setter = "feeStrategy")]
+    pub fn set_fee_strategy(&mut self, js_fee_strategy: Vec<AddressFundsFeeStrategyStepWASM>) {
+        self.0.set_fee_strategy(
+            js_fee_strategy
+                .iter()
+                .map(|step| step.clone().into())
+                .collect(),
+        )
+    }
+
+    #[wasm_bindgen(setter = "userFeeIncrease")]
+    pub fn set_user_fee_increase(&mut self, user_fee_increase: UserFeeIncrease) {
+        self.0.set_user_fee_increase(user_fee_increase)
+    }
+
+    #[wasm_bindgen(setter = "inputWitness")]
+    pub fn set_input_witness(&mut self, js_input_witnesses: &JsValue) -> Result<(), JsValue> {
+        let js_array_input_witnesses = Array::from(js_input_witnesses);
+        let input_witnesses = js_array_input_witnesses
+            .iter()
+            .map(|js_input| {
+                Ok::<AddressWitness, JsValue>(
+                    js_input
+                        .to_wasm::<AddressWitnessWASM>("AddressWitnessWASM")?
+                        .clone()
+                        .into(),
+                )
+            })
+            .collect::<Result<Vec<AddressWitness>, JsValue>>()?;
+
+        self.0.set_witnesses(input_witnesses);
+
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = "fromStateTransition")]
+    pub fn from_state_transition(
+        st: &StateTransitionWASM,
+    ) -> Result<IdentityTopUpFromAddressesTransitionWASM, JsValue> {
+        let rs_st: StateTransition = st.clone().into();
+
+        match rs_st {
+            StateTransition::IdentityTopUpFromAddresses(st) => {
+                Ok(IdentityTopUpFromAddressesTransitionWASM(st))
+            }
+            _ => Err(JsValue::from_str(&"Invalid state transition type)")),
+        }
+    }
+
+    #[wasm_bindgen(js_name = "toStateTransition")]
+    pub fn to_state_transition(&self) -> StateTransitionWASM {
+        StateTransitionWASM::from(StateTransition::from(self.0.clone()))
+    }
+}

--- a/packages/identity_transitions/src/create_transition/mod.rs
+++ b/packages/identity_transitions/src/create_transition/mod.rs
@@ -8,7 +8,7 @@ use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
 use dpp::state_transition::identity_create_transition::accessors::IdentityCreateTransitionAccessorsV0;
 use dpp::state_transition::identity_create_transition::v0::IdentityCreateTransitionV0;
 use dpp::state_transition::public_key_in_creation::IdentityPublicKeyInCreation;
-use dpp::state_transition::{StateTransition, StateTransitionLike};
+use dpp::state_transition::{StateTransition, StateTransitionLike, StateTransitionSingleSigned};
 use pshenmic_dpp_asset_lock_proof::AssetLockProofWASM;
 use pshenmic_dpp_enums::platform::PlatformVersionWASM;
 use pshenmic_dpp_identifier::IdentifierWASM;
@@ -180,9 +180,7 @@ impl IdentityCreateTransitionWASM {
 
         match rs_st {
             StateTransition::IdentityCreate(st) => Ok(IdentityCreateTransitionWASM(st)),
-            _ => Err(JsValue::from_str(
-                &"Invalid state document_transition type)",
-            )),
+            _ => Err(JsValue::from_str(&"Invalid state transition type)")),
         }
     }
 }

--- a/packages/identity_transitions/src/credit_withdrawal_transition/mod.rs
+++ b/packages/identity_transitions/src/credit_withdrawal_transition/mod.rs
@@ -9,7 +9,10 @@ use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable}
 use dpp::state_transition::identity_credit_withdrawal_transition::IdentityCreditWithdrawalTransition;
 use dpp::state_transition::identity_credit_withdrawal_transition::accessors::IdentityCreditWithdrawalTransitionAccessorsV0;
 use dpp::state_transition::identity_credit_withdrawal_transition::v1::IdentityCreditWithdrawalTransitionV1;
-use dpp::state_transition::{StateTransition, StateTransitionIdentitySigned, StateTransitionLike};
+use dpp::state_transition::{
+    StateTransition, StateTransitionIdentitySigned, StateTransitionLike,
+    StateTransitionSingleSigned,
+};
 use pshenmic_dpp_asset_lock_proof::AssetLockProofWASM;
 use pshenmic_dpp_core_script::CoreScriptWASM;
 use pshenmic_dpp_enums::keys::purpose::PurposeWASM;

--- a/packages/identity_transitions/src/identity_credit_transfer_transition/mod.rs
+++ b/packages/identity_transitions/src/identity_credit_transfer_transition/mod.rs
@@ -6,7 +6,10 @@ use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable}
 use dpp::state_transition::identity_credit_transfer_transition::IdentityCreditTransferTransition;
 use dpp::state_transition::identity_credit_transfer_transition::accessors::IdentityCreditTransferTransitionAccessorsV0;
 use dpp::state_transition::identity_credit_transfer_transition::v0::IdentityCreditTransferTransitionV0;
-use dpp::state_transition::{StateTransition, StateTransitionIdentitySigned, StateTransitionLike};
+use dpp::state_transition::{
+    StateTransition, StateTransitionIdentitySigned, StateTransitionLike,
+    StateTransitionSingleSigned,
+};
 use pshenmic_dpp_identifier::IdentifierWASM;
 use pshenmic_dpp_state_transition::StateTransitionWASM;
 use pshenmic_dpp_utils::WithJsError;

--- a/packages/identity_transitions/src/lib.rs
+++ b/packages/identity_transitions/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod address_transitions;
 pub mod create_transition;
 pub mod credit_withdrawal_transition;
 pub mod identity_credit_transfer_transition;

--- a/packages/identity_transitions/src/top_up_transition/mod.rs
+++ b/packages/identity_transitions/src/top_up_transition/mod.rs
@@ -7,7 +7,7 @@ use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable}
 use dpp::state_transition::identity_topup_transition::IdentityTopUpTransition;
 use dpp::state_transition::identity_topup_transition::accessors::IdentityTopUpTransitionAccessorsV0;
 use dpp::state_transition::identity_topup_transition::v0::IdentityTopUpTransitionV0;
-use dpp::state_transition::{StateTransition, StateTransitionLike};
+use dpp::state_transition::{StateTransition, StateTransitionLike, StateTransitionSingleSigned};
 use pshenmic_dpp_asset_lock_proof::AssetLockProofWASM;
 use pshenmic_dpp_identifier::IdentifierWASM;
 use pshenmic_dpp_state_transition::StateTransitionWASM;

--- a/packages/identity_transitions/src/update_transition/mod.rs
+++ b/packages/identity_transitions/src/update_transition/mod.rs
@@ -8,7 +8,10 @@ use dpp::state_transition::identity_update_transition::IdentityUpdateTransition;
 use dpp::state_transition::identity_update_transition::accessors::IdentityUpdateTransitionAccessorsV0;
 use dpp::state_transition::identity_update_transition::v0::IdentityUpdateTransitionV0;
 use dpp::state_transition::public_key_in_creation::IdentityPublicKeyInCreation;
-use dpp::state_transition::{StateTransition, StateTransitionIdentitySigned, StateTransitionLike};
+use dpp::state_transition::{
+    StateTransition, StateTransitionIdentitySigned, StateTransitionLike,
+    StateTransitionSingleSigned,
+};
 use pshenmic_dpp_asset_lock_proof::AssetLockProofWASM;
 use pshenmic_dpp_enums::keys::purpose::PurposeWASM;
 use pshenmic_dpp_identifier::IdentifierWASM;

--- a/packages/masternode_vote/src/lib.rs
+++ b/packages/masternode_vote/src/lib.rs
@@ -13,7 +13,10 @@ use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable}
 use dpp::state_transition::masternode_vote_transition::MasternodeVoteTransition;
 use dpp::state_transition::masternode_vote_transition::accessors::MasternodeVoteTransitionAccessorsV0;
 use dpp::state_transition::masternode_vote_transition::v0::MasternodeVoteTransitionV0;
-use dpp::state_transition::{StateTransition, StateTransitionIdentitySigned, StateTransitionLike};
+use dpp::state_transition::{
+    StateTransition, StateTransitionIdentitySigned, StateTransitionLike,
+    StateTransitionSingleSigned,
+};
 use pshenmic_dpp_asset_lock_proof::AssetLockProofWASM;
 use pshenmic_dpp_identifier::IdentifierWASM;
 use pshenmic_dpp_state_transition::StateTransitionWASM;
@@ -219,9 +222,7 @@ impl MasternodeVoteTransitionWASM {
 
         match rs_st {
             StateTransition::MasternodeVote(st) => Ok(MasternodeVoteTransitionWASM(st)),
-            _ => Err(JsValue::from_str(
-                &"Invalid state document_transition type)",
-            )),
+            _ => Err(JsValue::from_str(&"Invalid state transition type)")),
         }
     }
 }

--- a/packages/platform_address/Cargo.toml
+++ b/packages/platform_address/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pshenmic_dpp_identity_transitions"
+name = "pshenmic_dpp_platform_address"
 edition = "2024"
 version.workspace = true
 
@@ -13,10 +13,6 @@ dpp = { workspace = true, features = [
 ]}
 js-sys = { workspace = true }
 pshenmic_dpp_utils = {path = "../utils"}
-pshenmic_dpp_platform_address = {path = "../platform_address"}
-pshenmic_dpp_core_script = {path = "../core_script"}
-pshenmic_dpp_identity_public_key = {path = "../identity_public_key" }
-pshenmic_dpp_identifier = {path = "../identifier" }
-pshenmic_dpp_state_transition = {path = "../state_transition"}
 pshenmic_dpp_enums = {path = "../enums"}
+pshenmic_dpp_identifier = {path = "../identifier" }
 pshenmic_dpp_asset_lock_proof = {path = "../asset_lock_proof"}

--- a/packages/platform_address/src/address_witness.rs
+++ b/packages/platform_address/src/address_witness.rs
@@ -1,0 +1,95 @@
+use dpp::address_funds::AddressWitness;
+use dpp::platform_value::BinaryData;
+use js_sys::{Object, Reflect, Uint8Array};
+use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Clone)]
+#[wasm_bindgen(js_name = "AddressWitnessWASM")]
+pub struct AddressWitnessWASM(AddressWitness);
+
+impl From<AddressWitness> for AddressWitnessWASM {
+    fn from(value: AddressWitness) -> Self {
+        AddressWitnessWASM(value)
+    }
+}
+
+impl From<AddressWitnessWASM> for AddressWitness {
+    fn from(value: AddressWitnessWASM) -> Self {
+        value.0
+    }
+}
+
+#[wasm_bindgen]
+impl AddressWitnessWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "AddressWitnessWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "AddressWitnessWASM".to_string()
+    }
+
+    #[wasm_bindgen(js_name = "P2PKH")]
+    pub fn p2pkh(&self, signature: Uint8Array) -> AddressWitnessWASM {
+        AddressWitnessWASM(AddressWitness::P2pkh {
+            signature: BinaryData(signature.to_vec()),
+        })
+    }
+
+    #[wasm_bindgen(js_name = "P2SH")]
+    pub fn p2sh(
+        &self,
+        signatures: Vec<Uint8Array>,
+        redeem_script: Uint8Array,
+    ) -> AddressWitnessWASM {
+        AddressWitnessWASM(AddressWitness::P2sh {
+            signatures: signatures
+                .iter()
+                .map(|sig| BinaryData(sig.to_vec().clone()))
+                .collect(),
+            redeem_script: BinaryData(redeem_script.to_vec()),
+        })
+    }
+
+    #[wasm_bindgen(js_name = "getType")]
+    pub fn get_type(&self) -> String {
+        match self.0 {
+            AddressWitness::P2pkh { .. } => "P2PKH",
+            AddressWitness::P2sh { .. } => "P2SH",
+        }
+        .to_string()
+    }
+
+    #[wasm_bindgen(js_name = "getValue")]
+    pub fn get_value(&self) -> Result<JsValue, JsValue> {
+        let obj = Object::new();
+
+        match self.0.clone() {
+            AddressWitness::P2pkh { signature } => {
+                Reflect::set(
+                    &obj,
+                    &JsValue::from("signature"),
+                    &Uint8Array::new_from_slice(signature.0.as_slice()).into(),
+                )?;
+            }
+            AddressWitness::P2sh {
+                signatures,
+                redeem_script,
+            } => {
+                let js_signatures: Vec<Uint8Array> = signatures
+                    .iter()
+                    .map(|sig| Uint8Array::new_from_slice(sig.as_slice()))
+                    .collect();
+                let js_redeem_script = Uint8Array::from(redeem_script.as_slice());
+
+                Reflect::set(&obj, &"signatures".into(), &js_signatures.into())?;
+                Reflect::set(&obj, &"redeemScript".into(), &js_redeem_script.into())?;
+            }
+        };
+
+        Ok(obj.into())
+    }
+}

--- a/packages/platform_address/src/lib.rs
+++ b/packages/platform_address/src/lib.rs
@@ -1,0 +1,70 @@
+pub mod address_witness;
+
+use dpp::address_funds::PlatformAddress;
+use pshenmic_dpp_enums::network::NetworkWASM;
+use pshenmic_dpp_utils::WithJsError;
+use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Clone)]
+#[wasm_bindgen(js_name = "PlatformAddressWASM")]
+pub struct PlatformAddressWASM(PlatformAddress);
+
+impl From<PlatformAddress> for PlatformAddressWASM {
+    fn from(platform: PlatformAddress) -> Self {
+        Self(platform)
+    }
+}
+
+impl From<PlatformAddressWASM> for PlatformAddress {
+    fn from(platform: PlatformAddressWASM) -> Self {
+        platform.0
+    }
+}
+
+#[wasm_bindgen]
+impl PlatformAddressWASM {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "PlatformAddressWASM".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "PlatformAddressWASM".to_string()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(address: Vec<u8>) -> Result<PlatformAddressWASM, JsValue> {
+        Ok(PlatformAddressWASM(
+            PlatformAddress::from_bytes(address.as_slice()).with_js_error()?,
+        ))
+    }
+
+    #[wasm_bindgen(js_name = "bytes")]
+    pub fn address(&self) -> Vec<u8> {
+        self.0.to_bytes()
+    }
+
+    #[wasm_bindgen(js_name = "toAddress")]
+    pub fn to_address(&self, js_network: JsValue) -> Result<String, JsValue> {
+        let network = NetworkWASM::try_from(js_network)?;
+
+        Ok(self.0.to_address_with_network(network.into()).to_string())
+    }
+
+    #[wasm_bindgen(js_name = "isP2PKH")]
+    pub fn is_p2pkh(&self) -> bool {
+        self.0.is_p2pkh()
+    }
+
+    #[wasm_bindgen(js_name = "isP2SH")]
+    pub fn is_p2sh(&self) -> bool {
+        self.0.is_p2sh()
+    }
+
+    #[wasm_bindgen(js_name = "hash")]
+    pub fn hash(&self) -> Vec<u8> {
+        self.0.hash().to_vec()
+    }
+}

--- a/packages/state_transition/src/lib.rs
+++ b/packages/state_transition/src/lib.rs
@@ -8,7 +8,8 @@ use dpp::prelude::{IdentityNonce, UserFeeIncrease};
 use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable};
 use dpp::state_transition::StateTransition::{
     Batch, DataContractCreate, DataContractUpdate, IdentityCreditTransfer,
-    IdentityCreditWithdrawal, IdentityTopUp, IdentityUpdate, MasternodeVote,
+    IdentityCreditTransferToAddresses, IdentityCreditWithdrawal, IdentityTopUp,
+    IdentityTopUpFromAddresses, IdentityUpdate, MasternodeVote,
 };
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::batch_transition::batched_transition::BatchedTransition;
@@ -19,8 +20,10 @@ use dpp::state_transition::data_contract_create_transition::DataContractCreateTr
 use dpp::state_transition::data_contract_create_transition::accessors::DataContractCreateTransitionAccessorsV0;
 use dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
 use dpp::state_transition::data_contract_update_transition::accessors::DataContractUpdateTransitionAccessorsV0;
+use dpp::state_transition::identity_credit_transfer_to_addresses_transition::accessors::IdentityCreditTransferToAddressesTransitionAccessorsV0;
 use dpp::state_transition::identity_credit_transfer_transition::accessors::IdentityCreditTransferTransitionAccessorsV0;
 use dpp::state_transition::identity_credit_withdrawal_transition::accessors::IdentityCreditWithdrawalTransitionAccessorsV0;
+use dpp::state_transition::identity_topup_from_addresses_transition::accessors::IdentityTopUpFromAddressesTransitionAccessorsV0;
 use dpp::state_transition::identity_topup_transition::accessors::IdentityTopUpTransitionAccessorsV0;
 use dpp::state_transition::identity_update_transition::accessors::IdentityUpdateTransitionAccessorsV0;
 use dpp::state_transition::masternode_vote_transition::MasternodeVoteTransition;
@@ -304,6 +307,15 @@ impl StateTransitionWASM {
             IdentityCreditWithdrawal(_) => "IDENTITY_CREDIT_WITHDRAWAL",
             IdentityCreditTransfer(_) => "IDENTITY_CREDIT_TRANSFER",
             MasternodeVote(_) => "MASTERNODE_VOTE",
+            StateTransition::IdentityCreditTransferToAddresses(_) => {
+                "IDENTITY_CREDIT_TRANSFER_TO_ADDRESSES"
+            }
+            StateTransition::IdentityCreateFromAddresses(_) => "IDENTITY_CREATE_FROM_ADDRESSES",
+            StateTransition::IdentityTopUpFromAddresses(_) => "IDENTITY_TOP_UP_FROM_ADDRESSES",
+            StateTransition::AddressFundsTransfer(_) => "ADDRESS_FUNDS_TRANSFER",
+            StateTransition::AddressFundingFromAssetLock(_) => "ADDRESS_FUNDING_FROM_ASSET_LOCK",
+
+            StateTransition::AddressCreditWithdrawal(_) => "ADDRESS_CREDIT_WITHDRAWAL",
         }
         .to_string()
     }
@@ -320,17 +332,23 @@ impl StateTransitionWASM {
             IdentityCreditWithdrawal(_) => 6,
             IdentityCreditTransfer(_) => 7,
             MasternodeVote(_) => 8,
+            StateTransition::IdentityCreditTransferToAddresses(_) => 9,
+            StateTransition::IdentityCreateFromAddresses(_) => 10,
+            StateTransition::IdentityTopUpFromAddresses(_) => 11,
+            StateTransition::AddressFundsTransfer(_) => 12,
+            StateTransition::AddressFundingFromAssetLock(_) => 13,
+            StateTransition::AddressCreditWithdrawal(_) => 14,
         }
     }
 
     #[wasm_bindgen(js_name = "getOwnerId")]
-    pub fn get_owner_id(&self) -> IdentifierWASM {
-        self.0.owner_id().into()
+    pub fn get_owner_id(&self) -> Option<IdentifierWASM> {
+        self.0.owner_id().map(Into::into)
     }
 
     #[wasm_bindgen(getter = "signature")]
-    pub fn get_signature(&self) -> Vec<u8> {
-        self.0.signature().to_vec()
+    pub fn get_signature(&self) -> Option<Vec<u8>> {
+        self.0.signature().map(|bytes| bytes.to_vec())
     }
 
     #[wasm_bindgen(getter = "signaturePublicKeyId")]
@@ -400,6 +418,12 @@ impl StateTransitionWASM {
             IdentityUpdate(_) => None,
             IdentityCreditTransfer(_) => None,
             MasternodeVote(_) => None,
+            StateTransition::IdentityCreditTransferToAddresses(_) => None,
+            StateTransition::IdentityCreateFromAddresses(_) => None,
+            StateTransition::IdentityTopUpFromAddresses(_) => None,
+            StateTransition::AddressFundsTransfer(_) => None,
+            StateTransition::AddressFundingFromAssetLock(_) => None,
+            StateTransition::AddressCreditWithdrawal(_) => None,
         }
     }
 
@@ -415,11 +439,17 @@ impl StateTransitionWASM {
             IdentityUpdate(identity_update) => Some(identity_update.nonce()),
             IdentityCreditTransfer(credit_transfer) => Some(credit_transfer.nonce()),
             MasternodeVote(mn_vote) => Some(mn_vote.nonce()),
+            StateTransition::IdentityCreditTransferToAddresses(st) => Some(st.nonce()),
+            StateTransition::IdentityCreateFromAddresses(_) => None,
+            StateTransition::IdentityTopUpFromAddresses(_) => None,
+            StateTransition::AddressFundsTransfer(_) => None,
+            StateTransition::AddressFundingFromAssetLock(_) => None,
+            StateTransition::AddressCreditWithdrawal(_) => None,
         }
     }
 
     #[wasm_bindgen(setter = "signature")]
-    pub fn set_signature(&mut self, signature: Vec<u8>) {
+    pub fn set_signature(&mut self, signature: Vec<u8>) -> bool {
         self.0.set_signature(BinaryData::from(signature))
     }
 
@@ -520,6 +550,36 @@ impl StateTransitionWASM {
 
                 self.0 = MasternodeVote(mn_vote);
             }
+            IdentityCreditTransferToAddresses(mut st) => {
+                st.set_identity_id(owner_id.into());
+
+                self.0 = IdentityCreditTransferToAddresses(st);
+            }
+            IdentityTopUpFromAddresses(mut st) => {
+                st.set_identity_id(owner_id.into());
+
+                self.0 = IdentityTopUpFromAddresses(st);
+            }
+            StateTransition::IdentityCreateFromAddresses(_) => {
+                Err(JsValue::from_str(
+                    "Cannot set owner for identity IdentityCreateFromAddresses",
+                ))?;
+            }
+            StateTransition::AddressFundsTransfer(_) => {
+                Err(JsValue::from_str(
+                    "Cannot set owner for identity AddressFundsTransfer",
+                ))?;
+            }
+            StateTransition::AddressFundingFromAssetLock(_) => {
+                Err(JsValue::from_str(
+                    "Cannot set owner for identity AddressFundingFromAssetLock",
+                ))?;
+            }
+            StateTransition::AddressCreditWithdrawal(_) => {
+                Err(JsValue::from_str(
+                    "Cannot set owner for identity AddressCreditWithdrawal",
+                ))?;
+            }
         };
 
         Ok(())
@@ -560,6 +620,24 @@ impl StateTransitionWASM {
             ))?,
             MasternodeVote(_) => Err(JsValue::from_str(
                 "Cannot set identity contract nonce for Masternode Vote",
+            ))?,
+            IdentityCreditTransferToAddresses(_) => Err(JsValue::from_str(
+                "Cannot set identity contract nonce for IdentityCreditTransferToAddresses",
+            ))?,
+            StateTransition::IdentityCreateFromAddresses(_) => Err(JsValue::from_str(
+                "Cannot set identity contract nonce for IdentityCreateFromAddresses",
+            ))?,
+            IdentityTopUpFromAddresses(_) => Err(JsValue::from_str(
+                "Cannot set identity contract nonce for IdentityTopUpFromAddresses",
+            ))?,
+            StateTransition::AddressFundsTransfer(_) => Err(JsValue::from_str(
+                "Cannot set identity contract nonce for AddressFundsTransfer",
+            ))?,
+            StateTransition::AddressFundingFromAssetLock(_) => Err(JsValue::from_str(
+                "Cannot set identity contract nonce for AddressFundingFromAssetLock",
+            ))?,
+            StateTransition::AddressCreditWithdrawal(_) => Err(JsValue::from_str(
+                "Cannot set identity contract nonce for AddressCreditWithdrawal",
             ))?,
         };
 
@@ -615,6 +693,26 @@ impl StateTransitionWASM {
 
                 mn_vote.into()
             }
+            IdentityCreditTransferToAddresses(mut st) => {
+                st.set_nonce(nonce);
+
+                st.into()
+            }
+            StateTransition::IdentityCreateFromAddresses(_) => Err(JsValue::from_str(
+                "Cannot set identity nonce for IdentityCreateFromAddresses",
+            ))?,
+            IdentityTopUpFromAddresses(_) => Err(JsValue::from_str(
+                "Cannot set identity nonce for IdentityTopUpFromAddresses",
+            ))?,
+            StateTransition::AddressFundsTransfer(_) => Err(JsValue::from_str(
+                "Cannot set identity nonce for AddressFundsTransfer",
+            ))?,
+            StateTransition::AddressFundingFromAssetLock(_) => Err(JsValue::from_str(
+                "Cannot set identity nonce for AddressFundingFromAssetLock",
+            ))?,
+            StateTransition::AddressCreditWithdrawal(_) => Err(JsValue::from_str(
+                "Cannot set identity nonce for AddressCreditWithdrawal",
+            ))?,
         };
 
         Ok(())

--- a/packages/verify/Cargo.toml
+++ b/packages/verify/Cargo.toml
@@ -16,6 +16,7 @@ dpp = { workspace = true, features = [
 js-sys = { workspace = true }
 indexmap = { version = "2.0.2" }
 pshenmic_dpp_data_contract = { path = "../data_contract" }
+pshenmic_dpp_platform_address = { path = "../platform_address" }
 pshenmic_dpp_document = { path = "../document" }
 pshenmic_dpp_identifier = { path = "../identifier" }
 pshenmic_dpp_identity = { path = "../identity" }

--- a/packages/verify/src/verify_state_transition/utils.rs
+++ b/packages/verify/src/verify_state_transition/utils.rs
@@ -11,6 +11,7 @@ use pshenmic_dpp_identifier::IdentifierWASM;
 use pshenmic_dpp_identity::IdentityWASM;
 use pshenmic_dpp_masternode_vote::vote::VoteWASM;
 use pshenmic_dpp_partial_identity::PartialIdentityWASM;
+use pshenmic_dpp_platform_address::PlatformAddressWASM;
 use wasm_bindgen::JsValue;
 
 pub fn state_transition_proof_result_to_js(
@@ -215,6 +216,105 @@ pub fn state_transition_proof_result_to_js(
         }
         StateTransitionProofResult::VerifiedNextDistribution(vote) => {
             Ok(VoteWASM::from(vote.clone()).into())
+        }
+        StateTransitionProofResult::VerifiedAddressInfos(infos) => {
+            let infos_arr = Array::new();
+
+            for (address, amounts) in infos.iter() {
+                let info_obj = Object::new();
+
+                Reflect::set(
+                    &info_obj,
+                    &"address".into(),
+                    &PlatformAddressWASM::from(address.clone()).into(),
+                )?;
+                Reflect::set(
+                    &info_obj,
+                    &"nonce".into(),
+                    &amounts.unwrap_or((0, 0)).0.into(),
+                )?;
+                Reflect::set(
+                    &info_obj,
+                    &"credits".into(),
+                    &amounts.unwrap_or((0, 0)).1.into(),
+                )?;
+
+                infos_arr.push(&info_obj.into());
+            }
+
+            Ok(infos_arr.into())
+        }
+        StateTransitionProofResult::VerifiedIdentityFullWithAddressInfos(identity, infos) => {
+            let out_obj = Object::new();
+            let infos_arr = Array::new();
+
+            Reflect::set(
+                &out_obj,
+                &"identity".into(),
+                &IdentityWASM::from(identity.clone()).into(),
+            )?;
+
+            for (address, amounts) in infos.iter() {
+                let info_obj = Object::new();
+
+                Reflect::set(
+                    &info_obj,
+                    &"address".into(),
+                    &PlatformAddressWASM::from(address.clone()).into(),
+                )?;
+                Reflect::set(
+                    &info_obj,
+                    &"nonce".into(),
+                    &amounts.unwrap_or((0, 0)).0.into(),
+                )?;
+                Reflect::set(
+                    &info_obj,
+                    &"credits".into(),
+                    &amounts.unwrap_or((0, 0)).1.into(),
+                )?;
+
+                infos_arr.push(&info_obj.into());
+            }
+
+            Reflect::set(&out_obj, &"info".into(), &infos_arr.into())?;
+
+            Ok(out_obj.into())
+        }
+        StateTransitionProofResult::VerifiedIdentityWithAddressInfos(identity, infos) => {
+            let out_obj = Object::new();
+            let infos_arr = Array::new();
+
+            Reflect::set(
+                &out_obj,
+                &"partialIdentity".into(),
+                &PartialIdentityWASM::from(identity.clone()).into(),
+            )?;
+
+            for (address, amounts) in infos.iter() {
+                let info_obj = Object::new();
+
+                Reflect::set(
+                    &info_obj,
+                    &"address".into(),
+                    &PlatformAddressWASM::from(address.clone()).into(),
+                )?;
+                Reflect::set(
+                    &info_obj,
+                    &"nonce".into(),
+                    &amounts.unwrap_or((0, 0)).0.into(),
+                )?;
+                Reflect::set(
+                    &info_obj,
+                    &"credits".into(),
+                    &amounts.unwrap_or((0, 0)).1.into(),
+                )?;
+
+                infos_arr.push(&info_obj.into());
+            }
+
+            Reflect::set(&out_obj, &"info".into(), &infos_arr.into())?;
+
+            Ok(out_obj.into())
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,5 +22,6 @@ pub use pshenmic_dpp_identity;
 pub use pshenmic_dpp_identity_transitions;
 pub use pshenmic_dpp_masternode_vote;
 pub use pshenmic_dpp_partial_identity;
+pub use pshenmic_dpp_platform_address;
 pub use pshenmic_dpp_state_transition;
 pub use pshenmic_dpp_verify;


### PR DESCRIPTION
# Issue
We need to bump platform dependency version to 3.0.0-rc.1
# Things done
- Bumpled platform version
- Implemented:
  - `AddressCreditWithdrawalTransitionWASM`
  - `AddressFundingFromAssetLockTransitionWASM`
  - `AddressFundsFeeStrategyStepWASM`
  - `AddressFundsTransferTransitionWASM`
  - `IdentityCreateFromAddressesTransitionWASM`
  - `IdentityCreditTransferToAddressesTransitionWASM`
  - `OutputAddressWASM`
  - `InputAddressWASM`
  - `IdentityTopUpFromAddressesTransitionWASM`
  - `RecipientAddressWASM`
  - `AddressWitnessWASM`
  - `PlatformAddressWASM`
- Updated some olds bindings
- rust version bumped to 1.92.0
- Bump version
