### PR TITLE
Added `jsonLike` arg for `valueFromDynamicValue`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "2.0.0-dev.5"
+version = "2.0.0-dev.6"
 dependencies = [
  "dpp",
  "drive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pshenmic-dpp"
 authors = ["owl352 <kokosinca123@gmail.com>"]
-version = "2.0.0-dev.5"
+version = "2.0.0-dev.6"
 edition = "2024"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "2.0.0-dev.5",
+  "version": "2.0.0-dev.6",
   "main": "dist/src/wasm.js",
   "types": "dist/src/wasm.d.ts",
   "react-native": "./dist/src/react-native.js",

--- a/pkg/src/dpp/structs/Batch/DocumentTransitions/DocumentCreateTransition.ts
+++ b/pkg/src/dpp/structs/Batch/DocumentTransitions/DocumentCreateTransition.ts
@@ -25,8 +25,8 @@ export class DocumentCreateTransitionWASM {
     )
   }
 
-  get data (): object {
-    return valueFromDynamicValue(this._rawDocumentCreateTransition.data)
+  get data (): any {
+    return valueFromDynamicValue(this._rawDocumentCreateTransition.data, true)
   }
 
   set data (value: object) {

--- a/pkg/src/dpp/structs/Batch/DocumentTransitions/DocumentReplaceTransition.ts
+++ b/pkg/src/dpp/structs/Batch/DocumentTransitions/DocumentReplaceTransition.ts
@@ -22,8 +22,8 @@ export class DocumentReplaceTransitionWASM {
     )
   }
 
-  get data (): object {
-    return valueFromDynamicValue(this._rawDocumentReplaceTransition.data)
+  get data (): any {
+    return valueFromDynamicValue(this._rawDocumentReplaceTransition.data, true)
   }
 
   set data (value: object) {

--- a/pkg/src/dpp/structs/DataContract.ts
+++ b/pkg/src/dpp/structs/DataContract.ts
@@ -120,11 +120,11 @@ export class DataContractWASM {
     this._rawDataContract.keywords = value
   }
 
-  getSchemas (): object {
-    return valueFromDynamicValue(this._rawDataContract.getSchemas())
+  getSchemas (): any {
+    return valueFromDynamicValue(this._rawDataContract.getSchemas(), true)
   }
 
-  getConfig (): object {
+  getConfig (): any {
     return valueFromDynamicValue(this._rawDataContract.getConfig())
   }
 
@@ -144,11 +144,11 @@ export class DataContractWASM {
     return this._rawDataContract.base64(valueToDynamicValue(platformVersion))
   }
 
-  toJSON (platformVersion: PlatformVersionLike): object {
+  toJSON (platformVersion: PlatformVersionLike): any {
     return this._rawDataContract.toJson(valueToDynamicValue(platformVersion))
   }
 
-  toValue (platformVersion: PlatformVersionLike): object {
+  toValue (platformVersion: PlatformVersionLike): any {
     return valueFromDynamicValue(this._rawDataContract.toValue(valueToDynamicValue(platformVersion))) as object
   }
 

--- a/pkg/src/dpp/structs/Document.ts
+++ b/pkg/src/dpp/structs/Document.ts
@@ -61,8 +61,8 @@ export class DocumentWASM {
     this._rawDocument.ownerId = prepareIdentifierValue(value)
   }
 
-  get properties (): object {
-    return valueFromDynamicValue(this._rawDocument.properties)
+  get properties (): any {
+    return valueFromDynamicValue(this._rawDocument.properties, true)
   }
 
   set properties (value: object) {

--- a/pkg/src/dpp/utils.ts
+++ b/pkg/src/dpp/utils.ts
@@ -40,20 +40,25 @@ export function valueToDynamicValue (value: any): DynamicValue {
   }
 }
 
-export function valueFromDynamicValue (dynamicValue: DynamicValue): any {
+export function valueFromDynamicValue (dynamicValue: DynamicValue, jsonLike: boolean = false): any {
   if (dynamicValue.value instanceof dppProvider.dpp.DynamicValue) {
-    return valueToDynamicValue(dynamicValue.value)
+    return valueFromDynamicValue(dynamicValue.value, jsonLike)
   } else if (dynamicValue.isBigInt()) {
-    return BigInt(dynamicValue.value)
+    const num = BigInt(dynamicValue.value)
+    if (jsonLike && num < BigInt(Number.MAX_SAFE_INTEGER) && num > BigInt(Number.MIN_SAFE_INTEGER)) {
+      return Number(dynamicValue.value)
+    } else {
+      return num
+    }
   } else if (Array.isArray(dynamicValue.value)) {
-    return dynamicValue.value.map(valueFromDynamicValue)
+    return dynamicValue.value.map(v => valueFromDynamicValue(v, jsonLike))
   } else if (typeof dynamicValue.value === 'object' && !(dynamicValue.value instanceof Uint8Array) && dynamicValue.value !== null) {
     const obj: { [key: string]: any } = {}
 
     const keys: string[] = Object.keys(dynamicValue.value)
 
     for (const key of keys) {
-      obj[key] = valueFromDynamicValue(dynamicValue.value[key])
+      obj[key] = valueFromDynamicValue(dynamicValue.value[key], jsonLike)
     }
 
     return obj

--- a/tests/unit/DynamicValue.spec.ts
+++ b/tests/unit/DynamicValue.spec.ts
@@ -111,4 +111,16 @@ describe('DynamicValue', () => {
     expect(dynValue.value.stringInt.getType()).toStrictEqual('String')
     expect(dynValue.value.stringFloat.getType()).toStrictEqual('String')
   })
+
+  describe('should decode document from state transition in jsonLike', function () {
+    const stateTransition = dpp.StateTransitionWASM.fromBase64('AgHv88sfWzscuW2Ob/0v5d+EgqmWG7ZIvlQG7mHWBH7z9gEAAAAB7JH7W+JkM0Vne2U1zlWYVeQNzRPTpdiWRfsgfwNS2UoCCGJsb2dQb3N0KBdMgeznVQ1smUXVFNPfE2PC379wpWVH8cdu2ilzeI0Ah/i2xfrKCm5ACQAbEQkSc+GRUkdLor4Eu7Vzf6oRc9UHBmJsb2dJZAogdhC4nVm3ufPCgdfoOKXtnhqwg7O3axyTS9WB3EFvNBYPY29tbWVudHNFbmFibGVkEwEHY29udGVudAr7AUh4nM2TTWrDMBCFrxK0jkCyJMvqLnRV6A1KFhpplJgotrEVaAi+e8clpdBuvCnNcn7ezPvQ6O3G2siemKgNSGETT8ZarhUm7hpX8yStEpVCk6xlW1auA1L34Ed/GP1wpNQw9sPEnm6s4Ht57nM/UkPE5C+5UBl8OB3G/tLF37VFscvtoTtjV6iSMRU2b1nou/KZIXf3jUvrXUHRrosbv8ltKRk30JbNl2LLpnLNuPiZ5z1NOrY5jtjRqP28vbM656zTleagJHCNXnIQiUIpgozGg2/0N2s4Yji9tlN5KXj+A97FJG1AcpZ8nnANv1wHGo22ASrFXQDJde0SBzDIdQBVRQEoDDw2aLUONPkKtfF0s9bR9bqGkJW3PNYCg/FOgIqPDarWgQrRxKapBXdCJ3pR7TjUVnJrpAo6yhSc/4dv+tPu/gNBt2qtC3B1Ymxpc2hlZEF0Av0AAAGcptJlIwRzbHVnEhV0aGlzLWlzLW15LWZpcnN0LXBvc3QIc3VidGl0bGUSD1dpdGggYSBzdWJ0aXRsZQV0aXRsZRIVVGhpcyBpcyBteSBmaXJzdCBwb3N0AAABQR+H40MbUEmFXQbTPcwy9vMD8EiTwDzMpW3YIkfSIDvHij5ZIAVvqm0ZJScJzKV7EnRUi/f1tZ/wFJfd1+LDtpps')
+
+    const batch = dpp.BatchTransitionWASM.fromStateTransition(stateTransition)
+
+    const transition = batch.transitions[0].toTransition() as dpp.DocumentTransitionWASM
+
+    const publishedAt = transition.createTransition.data.publishedAt
+
+    expect(typeof publishedAt).toEqual('number')
+  })
 })


### PR DESCRIPTION
# Issue
We found bug on testnet Platform Explorer. Some fields for document and data contract can contains BigInt for timestamps and this is incorrect

# Things done
- Added `jsonLike` in `valueFromDynamicValue`. When this flag enabled we use number type for u64 and u128 if value lower than `Number.MAX_SAFE_INTEGER` or greater than `Number.MIN_SAFE_INTEGER`
- Fixed ts types (`any` instead `object`)
- Implemented new tests for dynamic value
- Bump version