### PR TITLE
Fix v2 package exports for browser bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   ],
   "exports": {
     ".": {
-      "node": "./dist/src/native.js",
       "react-native": "./dist/src/react-native.js",
       "default": "./dist/src/wasm.js"
     },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   ],
   "exports": {
     ".": {
+      "browser": "./dist/src/wasm.js",
+      "node": "./dist/src/native.js",
       "react-native": "./dist/src/react-native.js",
       "default": "./dist/src/wasm.js"
     },

--- a/templates/binaries/wasmCreation.cjs
+++ b/templates/binaries/wasmCreation.cjs
@@ -2,7 +2,7 @@ const { WASI } = require('@tybys/wasm-util');
 const { getDefaultContext } = require('@emnapi/runtime');
 const { instantiateNapiModuleSync } = require('@emnapi/core');
 const { bytes } = require('./wasm/wasmBytes.cjs');
-const { decode } = require('../utils/base122.js');
+const { decode } = require('../utils/base122.cjs');
 const { decompressSync } = require('fflate');
 
 const wasmBytes = new Uint8Array(decode(bytes));


### PR DESCRIPTION
Fixes #178.\n\nWhat changed:\n- Route the package root conditional export to the WASM build instead of selecting the native Node-API entry for Node-conditioned bundler resolution. The explicit pshenmic-dpp/native subpath remains available for native consumers.\n- Fix the generated WASM bootstrap template to require ../utils/base122.cjs, matching the emitted tarball file extension.\n\nVerification:\n- 
ode -e package export fixture: root pshenmic-dpp resolves to dist/src/wasm.js; pshenmic-dpp/native resolves to dist/src/native.js.\n- equire.resolve('../utils/base122.cjs') from the generated-template directory resolves to 	emplates/utils/base122.cjs.\n- git diff --check passed with only existing LF-to-CRLF warnings on touched files.