### PR TITLE
Pass tokens configuration before data contract creation

### DIFF
--- a/src/data_contract/mod.rs
+++ b/src/data_contract/mod.rs
@@ -134,6 +134,21 @@ impl DataContractNAPI {
             .set_value("documentSchemas", schema)
             .map_err(|err| napi::Error::new(napi::Status::GenericFailure, err.to_string()))?;
 
+        let tokens_value_map: Vec<(Value, Value)> = tokens
+            .into_iter()
+            .map(|(pos, config)| {
+                platform_value::to_value(config)
+                    .map(|v| (Value::Text(pos.to_string()), v))
+                    .map_err(|err| {
+                        napi::Error::new(napi::Status::GenericFailure, err.to_string())
+                    })
+            })
+            .collect::<Result<_, napi::Error>>()?;
+
+        contract_value
+            .set_value("tokens", Value::Map(tokens_value_map))
+            .map_err(|err| napi::Error::new(napi::Status::GenericFailure, err.to_string()))?;
+
         let data_contract = DataContract::from_value(
             contract_value,
             full_validation.unwrap_or(true),
@@ -141,16 +156,7 @@ impl DataContractNAPI {
         )
         .with_js_error()?;
 
-        let data_contract_with_tokens = match data_contract {
-            DataContract::V0(v0) => DataContract::from(v0),
-            DataContract::V1(mut v1) => {
-                v1.set_tokens(tokens);
-
-                DataContract::from(v1)
-            }
-        };
-
-        Ok(DataContractNAPI(data_contract_with_tokens))
+        Ok(DataContractNAPI(data_contract))
     }
 
     #[napi(js_name = "fromValue")]

--- a/tests/unit/DataContract.spec.ts
+++ b/tests/unit/DataContract.spec.ts
@@ -1,0 +1,232 @@
+import { DataContractWASM, IdentifierWASM, PlatformVersionWASM } from 'pshenmic-dpp'
+import { buildTokenConfiguration } from './utils/buildTokenConfiguration'
+
+const OWNER_ID_BASE58 = 'HEAmUtC72dPcZ59yyLUgfS8pfrEWqzYfDPzTofgWxXRr'
+
+const DOCUMENT_SCHEMA = {
+  note: {
+    type: 'object',
+    properties: {
+      message: {
+        type: 'string',
+        position: 0
+      }
+    },
+    additionalProperties: false
+  }
+}
+
+describe('DataContract', function () {
+  describe('constructor', function () {
+    test('should create a contract with document schemas only', function () {
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        DOCUMENT_SCHEMA,
+        undefined,
+        undefined,
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      expect(contract).toBeInstanceOf(DataContractWASM)
+      expect(contract.ownerId.base58()).toEqual(OWNER_ID_BASE58)
+      expect(contract.tokens.length).toEqual(0)
+      expect(Object.keys(contract.getSchemas())).toEqual(['note'])
+    })
+
+    test('should create a tokens-only contract (no document schemas)', function () {
+      const tokenConfig = buildTokenConfiguration()
+
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        {},
+        undefined,
+        [{ position: 0, tokenConfiguration: tokenConfig }],
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      expect(contract).toBeInstanceOf(DataContractWASM)
+      expect(contract.tokens.length).toEqual(1)
+      expect(contract.tokens[0].position).toEqual(0)
+      expect(contract.tokens[0].tokenConfiguration.baseSupply).toEqual(BigInt(100000))
+    })
+
+    test('should fail to create a contract with neither documents nor tokens', function () {
+      expect(() => new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        {},
+        undefined,
+        undefined,
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )).toThrow()
+    })
+
+    test('should create a contract with both documents and tokens', function () {
+      const tokenConfig = buildTokenConfiguration({ baseSupply: BigInt(50) })
+
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        DOCUMENT_SCHEMA,
+        undefined,
+        [{ position: 0, tokenConfiguration: tokenConfig }],
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      expect(contract.tokens.length).toEqual(1)
+      expect(Object.keys(contract.getSchemas())).toEqual(['note'])
+    })
+
+    test('should generate a deterministic id from owner id and nonce', function () {
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(42),
+        DOCUMENT_SCHEMA,
+        undefined,
+        undefined,
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      const expectedId = DataContractWASM.generateId(OWNER_ID_BASE58, BigInt(42))
+
+      expect(contract.id.base58()).toEqual(expectedId.base58())
+    })
+  })
+
+  describe('serialization', function () {
+    test('should serialize / deserialize via bytes', function () {
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        DOCUMENT_SCHEMA,
+        undefined,
+        undefined,
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      const bytes = contract.bytes(PlatformVersionWASM.PLATFORM_V10)
+      const restored = DataContractWASM.fromBytes(bytes, true, PlatformVersionWASM.PLATFORM_V10)
+
+      expect(restored.id.base58()).toEqual(contract.id.base58())
+      expect(restored.ownerId.base58()).toEqual(contract.ownerId.base58())
+    })
+
+    test('should serialize / deserialize a tokens-only contract via bytes', function () {
+      const tokenConfig = buildTokenConfiguration()
+
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        {},
+        undefined,
+        [{ position: 0, tokenConfiguration: tokenConfig }],
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      const bytes = contract.bytes(PlatformVersionWASM.PLATFORM_V10)
+      const restored = DataContractWASM.fromBytes(bytes, true, PlatformVersionWASM.PLATFORM_V10)
+
+      expect(restored.tokens.length).toEqual(1)
+      expect(restored.tokens[0].tokenConfiguration.baseSupply).toEqual(tokenConfig.baseSupply)
+    })
+
+    test('should round-trip via hex', function () {
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        DOCUMENT_SCHEMA,
+        undefined,
+        undefined,
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      const hex = contract.hex(PlatformVersionWASM.PLATFORM_V10)
+      const restored = DataContractWASM.fromHex(hex, true, PlatformVersionWASM.PLATFORM_V10)
+
+      expect(restored.id.base58()).toEqual(contract.id.base58())
+    })
+
+    test('should round-trip via base64', function () {
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        DOCUMENT_SCHEMA,
+        undefined,
+        undefined,
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      const b64 = contract.base64(PlatformVersionWASM.PLATFORM_V10)
+      const restored = DataContractWASM.fromBase64(b64, true, PlatformVersionWASM.PLATFORM_V10)
+
+      expect(restored.id.base58()).toEqual(contract.id.base58())
+    })
+  })
+
+  describe('mutators', function () {
+    test('should allow setting tokens after construction', function () {
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        DOCUMENT_SCHEMA,
+        undefined,
+        undefined,
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      expect(contract.tokens.length).toEqual(0)
+
+      contract.tokens = [{ position: 0, tokenConfiguration: buildTokenConfiguration() }]
+
+      expect(contract.tokens.length).toEqual(1)
+    })
+
+    test('should allow setting and reading description / keywords', function () {
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        DOCUMENT_SCHEMA,
+        undefined,
+        undefined,
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      contract.description = 'test contract'
+      contract.keywords = ['alpha', 'beta']
+
+      expect(contract.description).toEqual('test contract')
+      expect(contract.keywords).toEqual(['alpha', 'beta'])
+    })
+
+    test('should allow changing the owner id', function () {
+      const contract = new DataContractWASM(
+        OWNER_ID_BASE58,
+        BigInt(1),
+        DOCUMENT_SCHEMA,
+        undefined,
+        undefined,
+        true,
+        PlatformVersionWASM.PLATFORM_V10
+      )
+
+      const newOwner = new IdentifierWASM('ckBqfQe7LU7vwrwXopyCB4n5phZShjA16BGhNGpsD5U')
+
+      contract.ownerId = newOwner
+
+      expect(contract.ownerId.base58()).toEqual(newOwner.base58())
+    })
+  })
+})

--- a/tests/unit/TokenConfiguration.spec.ts
+++ b/tests/unit/TokenConfiguration.spec.ts
@@ -1,0 +1,114 @@
+import {
+  AuthorizedActionTakersWASM,
+  IdentifierWASM,
+  TokenConfigurationWASM
+} from 'pshenmic-dpp'
+import { buildTokenConfiguration } from './utils/buildTokenConfiguration'
+
+describe('TokenConfiguration', function () {
+  describe('constructor', function () {
+    test('should build a token configuration with defaults from the helper', function () {
+      const config = buildTokenConfiguration()
+
+      expect(config).toBeInstanceOf(TokenConfigurationWASM)
+      expect(config.baseSupply).toEqual(BigInt(100000))
+      expect(config.maxSupply).toBeUndefined()
+      expect(config.description).toBeUndefined()
+      expect(config.startAsPaused).toEqual(false)
+      expect(config.isAllowedTransferToFrozenBalance).toEqual(false)
+    })
+
+    test('should set max supply and description when provided', function () {
+      const config = buildTokenConfiguration({
+        baseSupply: BigInt(500),
+        maxSupply: BigInt(1000),
+        description: 'hello'
+      })
+
+      expect(config.baseSupply).toEqual(BigInt(500))
+      expect(config.maxSupply).toEqual(BigInt(1000))
+      expect(config.description).toEqual('hello')
+    })
+  })
+
+  describe('getters', function () {
+    test('should expose the convention decimals', function () {
+      const config = buildTokenConfiguration()
+
+      expect(config.conventions.decimals).toEqual(8)
+    })
+
+    test('should default mainControlGroup to undefined', function () {
+      const config = buildTokenConfiguration()
+
+      expect(config.mainControlGroup).toBeUndefined()
+    })
+  })
+
+  describe('setters', function () {
+    test('should allow updating baseSupply', function () {
+      const config = buildTokenConfiguration()
+
+      config.baseSupply = BigInt(7)
+
+      expect(config.baseSupply).toEqual(BigInt(7))
+    })
+
+    test('should allow updating maxSupply to a value and back to undefined', function () {
+      const config = buildTokenConfiguration()
+
+      config.maxSupply = BigInt(42)
+      expect(config.maxSupply).toEqual(BigInt(42))
+
+      config.maxSupply = undefined
+      expect(config.maxSupply).toBeUndefined()
+    })
+
+    test('should allow updating description', function () {
+      const config = buildTokenConfiguration()
+
+      config.description = 'updated'
+
+      expect(config.description).toEqual('updated')
+    })
+
+    test('should allow updating startAsPaused / isAllowedTransferToFrozenBalance', function () {
+      const config = buildTokenConfiguration()
+
+      config.startAsPaused = true
+      config.isAllowedTransferToFrozenBalance = true
+
+      expect(config.startAsPaused).toEqual(true)
+      expect(config.isAllowedTransferToFrozenBalance).toEqual(true)
+    })
+
+    test('should allow updating mainControlGroup', function () {
+      const config = buildTokenConfiguration()
+
+      config.mainControlGroup = 3
+
+      expect(config.mainControlGroup).toEqual(3)
+    })
+
+    test('should allow updating mainControlGroupCanBeModified', function () {
+      const config = buildTokenConfiguration()
+
+      config.mainControlGroupCanBeModified = AuthorizedActionTakersWASM.ContractOwner()
+
+      expect(config.mainControlGroupCanBeModified).toBeDefined()
+    })
+  })
+
+  describe('calculateTokenId', function () {
+    test('should derive a deterministic token id from a contract id and position', function () {
+      const contractId = new IdentifierWASM('HEAmUtC72dPcZ59yyLUgfS8pfrEWqzYfDPzTofgWxXRr')
+
+      const tokenIdA = TokenConfigurationWASM.calculateTokenId(contractId, 0)
+      const tokenIdB = TokenConfigurationWASM.calculateTokenId(contractId, 0)
+      const tokenIdC = TokenConfigurationWASM.calculateTokenId(contractId, 1)
+
+      expect(tokenIdA.base58()).toEqual(tokenIdB.base58())
+      expect(tokenIdA.base58()).not.toEqual(tokenIdC.base58())
+    })
+  })
+})

--- a/tests/unit/utils/buildTokenConfiguration.ts
+++ b/tests/unit/utils/buildTokenConfiguration.ts
@@ -1,0 +1,66 @@
+import {
+  AuthorizedActionTakersWASM,
+  ChangeControlRulesWASM,
+  TokenConfigurationConventionWASM,
+  TokenConfigurationWASM,
+  TokenDistributionRulesWASM,
+  TokenKeepsHistoryRulesWASM,
+  TokenMarketplaceRulesWASM,
+  TokenTradeModeWASM
+} from 'pshenmic-dpp'
+
+export function buildChangeControlRules (): ChangeControlRulesWASM {
+  return new ChangeControlRulesWASM(
+    AuthorizedActionTakersWASM.NoOne(),
+    AuthorizedActionTakersWASM.NoOne(),
+    false,
+    false,
+    false
+  )
+}
+
+export function buildTokenConfiguration (
+  overrides: { baseSupply?: bigint, maxSupply?: bigint, description?: string } = {}
+): TokenConfigurationWASM {
+  const conventions = new TokenConfigurationConventionWASM({}, 8)
+
+  const keepsHistory = new TokenKeepsHistoryRulesWASM(false, false, false, false, false, false)
+
+  const distributionRules = new TokenDistributionRulesWASM(
+    buildChangeControlRules(),
+    buildChangeControlRules(),
+    false,
+    buildChangeControlRules(),
+    buildChangeControlRules(),
+    undefined,
+    undefined,
+    undefined
+  )
+
+  const marketplaceRules = new TokenMarketplaceRulesWASM(
+    TokenTradeModeWASM.NotTradeable(),
+    buildChangeControlRules()
+  )
+
+  return new TokenConfigurationWASM(
+    conventions,
+    buildChangeControlRules(),
+    overrides.baseSupply ?? BigInt(100000),
+    keepsHistory,
+    false,
+    false,
+    buildChangeControlRules(),
+    distributionRules,
+    marketplaceRules,
+    buildChangeControlRules(),
+    buildChangeControlRules(),
+    buildChangeControlRules(),
+    buildChangeControlRules(),
+    buildChangeControlRules(),
+    buildChangeControlRules(),
+    AuthorizedActionTakersWASM.NoOne(),
+    overrides.maxSupply,
+    undefined,
+    overrides.description
+  )
+}


### PR DESCRIPTION
# Issue
At this moment on `new DataContractWASM` with token configuration by alghoritm we first create contract and then set token, but that's an incorrect

# Things done
- Convert token configuration to platform value and pass with data contract value
- Implement a lot of tests for data contract and tokens