### PR TITLE
Bump package version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "2.0.0-dev.16"
+version = "2.0.0-dev.17"
 dependencies = [
  "dpp",
  "drive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pshenmic-dpp"
 authors = ["owl352 <kokosinca123@gmail.com>"]
-version = "2.0.0-dev.16"
+version = "2.0.0-dev.17"
 edition = "2024"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "2.0.0-dev.16",
+  "version": "2.0.0-dev.17",
   "main": "dist/src/wasm.js",
   "types": "dist/src/wasm.d.ts",
   "react-native": "./dist/src/react-native.js",


### PR DESCRIPTION
# Issue
For new release package version must be bumped to `2.0.0-dev.17`

# Things done
- Bump version in `package.json`
- Bump version in `Cargo.toml`
- Update `Cargo.lock`