### PR TITLE
Replace `const enum` with `enum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "2.0.0-dev.19"
+version = "2.0.0-dev.20"
 dependencies = [
  "dpp",
  "drive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pshenmic-dpp"
 authors = ["owl352 <kokosinca123@gmail.com>"]
-version = "2.0.0-dev.19"
+version = "2.0.0-dev.20"
 edition = "2024"
 
 [lib]

--- a/build.cjs
+++ b/build.cjs
@@ -178,7 +178,7 @@ async function main() {
   const types = fs.readFileSync(wasmTypesPath, { encoding: "utf8" });
   fs.writeFileSync(
     path.join(binariesOutputDir, "bindingsTypes.ts"),
-    types.replace(/declare const/g, "const"),
+    types.replace(/declare const/g, "const").replace(/const enum/g, 'enum'),
   );
 
   fs.writeFileSync(path.join(binariesOutputDir, "wasm.d.ts"), typingsForCodegen);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "2.0.0-dev.19",
+  "version": "2.0.0-dev.20",
   "main": "dist/src/wasm.js",
   "types": "dist/src/wasm.d.ts",
   "react-native": "./dist/src/react-native.js",


### PR DESCRIPTION
# Issue
Currently after build enums defined via `const enum` but const enum's doesn't allow to pass string var as a key of enum

# Things done
- Updated build script for replacing `const enum` on `enum`
- Bump package version