### PR TITLE
Fix identifier constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "2.0.0-dev.21"
+version = "2.0.0-dev.22"
 dependencies = [
  "async-trait",
  "dpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pshenmic-dpp"
 authors = ["owl352 <kokosinca123@gmail.com>"]
-version = "2.0.0-dev.21"
+version = "2.0.0-dev.22"
 edition = "2024"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "2.0.0-dev.21",
+  "version": "2.0.0-dev.22",
   "main": "dist/src/wasm.js",
   "types": "dist/src/wasm.d.ts",
   "react-native": "./dist/src/react-native.js",

--- a/pkg/src/dpp/structs/Identifier.ts
+++ b/pkg/src/dpp/structs/Identifier.ts
@@ -15,6 +15,8 @@ export class IdentifierWASM {
       const id = new dpp.DynamicValue(rawId)
 
       this._rawIdentifier = new dpp.IdentifierNAPI(id)
+    } else if (rawId instanceof dpp.IdentifierNAPI) {
+      this._rawIdentifier = rawId
     } else {
       throw new Error('Invalid raw ID')
     }


### PR DESCRIPTION
# Issue
By types `IdentifierWASM` allows `IdentifierNAPI` as argument in constructor, but code doesn't process this type

# Things done
- Fix `IdentifierWASM` constructor
- Bump package version 