### PR TITLE
Аdd proofs for finalized epoch infos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "2.0.0-dev.22"
+version = "2.0.0-dev.23"
 dependencies = [
  "async-trait",
  "dpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pshenmic-dpp"
 authors = ["owl352 <kokosinca123@gmail.com>"]
-version = "2.0.0-dev.22"
+version = "2.0.0-dev.23"
 edition = "2024"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "2.0.0-dev.22",
+  "version": "2.0.0-dev.23",
   "main": "dist/src/wasm.js",
   "types": "dist/src/wasm.d.ts",
   "react-native": "./dist/src/react-native.js",

--- a/pkg/src/dpp/dpp.ts
+++ b/pkg/src/dpp/dpp.ts
@@ -115,6 +115,7 @@ export { BatchTransitionWASM } from './structs/Batch/BatchTransition.js'
 
 export { verifySignatureDigest } from './verify/verifySignatureDigest.js'
 export { verifyEpochsInfoProof } from './verify/System/verifyEpochsInfoProof.js'
+export { verifyFinalizedEpochInfosProof } from './verify/System/verifyFinalizedEpochInfosProof.js'
 export { verifyTotalCreditsProof } from './verify/System/verifyTotalCreditsProof.js'
 export { verifyVotePollVoteStateProof } from './verify/Contested/verifyVotePollVoteStateProof.js'
 export { verifyContractProof } from './verify/Contract/verifyContract.js'

--- a/pkg/src/dpp/types.ts
+++ b/pkg/src/dpp/types.ts
@@ -127,9 +127,30 @@ export interface ExtendedEpochInfo {
   protocolVersion: number
 }
 
+export interface FinalizedEpochInfo {
+  epochIndex: number
+  firstBlockTime: Date
+  firstBlockHeight: bigint
+  totalBlocksInEpoch: bigint
+  firstCoreBlockHeight: number
+  nextEpochStartCoreBlockHeight: number
+  totalProcessingFees: bigint
+  totalDistributedStorageFees: bigint
+  totalCreatedStorageFees: bigint
+  coreBlockRewards: bigint
+  blockProposers: {proposer: IdentifierWASM, count: bigint}[],
+  feeMultiplierPermille: bigint,
+  protocolVersion: number
+}
+
 export interface VerifiedEpochsInfo {
   rootHash: Uint8Array
   epochsInfo: ExtendedEpochInfo[]
+}
+
+export interface VerifiedFinalizedEpochsInfo {
+  rootHash: Uint8Array
+  epochInfos: FinalizedEpochInfo[]
 }
 
 export interface VerifiedTotalCredits {

--- a/pkg/src/dpp/verify/System/verifyFinalizedEpochInfosProof.ts
+++ b/pkg/src/dpp/verify/System/verifyFinalizedEpochInfosProof.ts
@@ -1,0 +1,44 @@
+import {dppProvider} from '../../provider.js'
+import {valueToDynamicValue} from '../../utils.js'
+import {PlatformVersionLike, VerifiedFinalizedEpochsInfo} from "../../types.js";
+import {IdentifierWASM} from "../../structs/Identifier.js";
+
+export function verifyFinalizedEpochInfosProof(
+  proof: Uint8Array,
+  startEpoch: number,
+  startEpochIncluded: boolean,
+  endEpoch: number,
+  endEpochIncluded: boolean,
+  platformVersion: PlatformVersionLike
+): VerifiedFinalizedEpochsInfo {
+  const result = dppProvider.dpp.verifyFinalizedEpochInfosProof(
+    proof,
+    startEpoch,
+    startEpochIncluded,
+    endEpoch,
+    endEpochIncluded,
+    valueToDynamicValue(platformVersion),
+  )
+
+  return {
+    rootHash: result.rootHash,
+    epochInfos: result.epochInfos.map(([epochIndex, info]) => ({
+      epochIndex: epochIndex,
+      firstBlockTime: new Date(Number(info.firstBlockTime)),
+      firstBlockHeight: BigInt(info.firstBlockHeight),
+      totalBlocksInEpoch: BigInt(info.totalBlocksInEpoch),
+      firstCoreBlockHeight: info.firstCoreBlockHeight,
+      nextEpochStartCoreBlockHeight: info.nextEpochStartCoreBlockHeight,
+      totalProcessingFees: BigInt(info.totalProcessingFees),
+      totalDistributedStorageFees: BigInt(info.totalDistributedStorageFees),
+      totalCreatedStorageFees: BigInt(info.totalCreatedStorageFees),
+      coreBlockRewards: BigInt(info.coreBlockRewards),
+      blockProposers: info.blockProposers.map(([proposer, count]) => ({
+        proposer: IdentifierWASM.createFromRawInstance(proposer),
+        count: BigInt(count),
+      })),
+      feeMultiplierPermille: BigInt(info.feeMultiplierPermille),
+      protocolVersion: info.protocolVersion,
+    }))
+  }
+}

--- a/src/verify/system/finalized_epoch_infos.rs
+++ b/src/verify/system/finalized_epoch_infos.rs
@@ -1,0 +1,133 @@
+use dpp::block::finalized_epoch_info::{
+    FinalizedEpochInfo, v0::getters::FinalizedEpochInfoGettersV0,
+};
+use drive::drive::Drive;
+use napi::bindgen_prelude::Uint8Array;
+use napi_derive::napi;
+
+use crate::{
+    dynamic_value::{BigIntString, DynamicValue, TryToU64},
+    enums::platform_version::PlatformVersionNAPI,
+    identifier::IdentifierNAPI,
+};
+
+#[derive(Clone)]
+#[napi(js_name = "FinalizedEpochInfoNAPI")]
+pub struct FinalizedEpochInfoNAPI(FinalizedEpochInfo);
+
+impl From<FinalizedEpochInfo> for FinalizedEpochInfoNAPI {
+    fn from(value: FinalizedEpochInfo) -> Self {
+        Self(value)
+    }
+}
+
+#[napi]
+impl FinalizedEpochInfoNAPI {
+    #[napi(getter, js_name = "firstBlockTime")]
+    pub fn first_block_time(&self) -> BigIntString {
+        BigIntString::from_u64(self.0.first_block_time())
+    }
+
+    #[napi(getter, js_name = "firstBlockHeight")]
+    pub fn first_block_height(&self) -> BigIntString {
+        BigIntString::from_u64(self.0.first_block_height())
+    }
+
+    #[napi(getter, js_name = "totalBlocksInEpoch")]
+    pub fn total_blocks_in_epoch(&self) -> BigIntString {
+        BigIntString::from_u64(self.0.total_blocks_in_epoch())
+    }
+
+    #[napi(getter, js_name = "firstCoreBlockHeight")]
+    pub fn first_core_block_height(&self) -> u32 {
+        self.0.first_core_block_height()
+    }
+
+    #[napi(getter, js_name = "nextEpochStartCoreBlockHeight")]
+    pub fn next_epoch_start_core_block_height(&self) -> u32 {
+        self.0.next_epoch_start_core_block_height()
+    }
+
+    #[napi(getter, js_name = "totalProcessingFees")]
+    pub fn total_processing_fees(&self) -> BigIntString {
+        BigIntString::from_u64(self.0.total_processing_fees())
+    }
+
+    #[napi(getter, js_name = "totalDistributedStorageFees")]
+    pub fn total_distributed_storage_fees(&self) -> BigIntString {
+        BigIntString::from_u64(self.0.total_distributed_storage_fees())
+    }
+
+    #[napi(getter, js_name = "totalCreatedStorageFees")]
+    pub fn total_created_storage_fees(&self) -> BigIntString {
+        BigIntString::from_u64(self.0.total_created_storage_fees())
+    }
+
+    #[napi(getter, js_name = "coreBlockRewards")]
+    pub fn core_block_rewards(&self) -> BigIntString {
+        BigIntString::from_u64(self.0.core_block_rewards())
+    }
+
+    #[napi(getter, js_name = "blockProposers")]
+    pub fn block_proposers(&self) -> Vec<(IdentifierNAPI, BigIntString)> {
+        self.0
+            .block_proposers()
+            .iter()
+            .map(|(k, v)| (k.clone().into(), BigIntString::from_u64(v.clone())))
+            .collect()
+    }
+
+    #[napi(getter, js_name = "feeMultiplierPermille")]
+    pub fn fee_multiplier_permille(&self) -> BigIntString {
+        BigIntString::from_u64(self.0.fee_multiplier_permille())
+    }
+
+    #[napi(getter, js_name = "protocolVersion")]
+    pub fn protocol_version(&self) -> u32 {
+        self.0.protocol_version()
+    }
+}
+
+#[napi(js_name = "VerifiedFinlizedEpochInfosNAPI")]
+pub struct VerifiedFinlizedEpochInfosNAPI {
+    pub root_hash: Uint8Array,
+    epoch_info: Vec<(u16, FinalizedEpochInfoNAPI)>,
+}
+
+#[napi]
+impl VerifiedFinlizedEpochInfosNAPI {
+    #[napi(getter, js_name = "epochInfos")]
+    pub fn get_epoch_infos(&self) -> Vec<(u16, FinalizedEpochInfoNAPI)> {
+        self.epoch_info.clone()
+    }
+}
+
+#[napi(js_name = "verifyFinalizedEpochInfosProof")]
+pub fn verify_finalized_epoch_infos(
+    proof: Uint8Array,
+    start_epoch_index: u16,
+    start_epoch_index_included: bool,
+    end_epoch_index: u16,
+    end_epoch_index_included: bool,
+    js_platform_version: &DynamicValue,
+) -> Result<VerifiedFinlizedEpochInfosNAPI, napi::Error> {
+    let platform_version = PlatformVersionNAPI::try_from(js_platform_version)?;
+
+    let (root_hash, epoch_infos) = Drive::verify_finalized_epoch_infos(
+        &proof.to_vec(),
+        start_epoch_index,
+        start_epoch_index_included,
+        end_epoch_index,
+        end_epoch_index_included,
+        &platform_version.into(),
+    )
+    .map_err(|e| napi::Error::new(napi::Status::GenericFailure, e.to_string()))?;
+
+    Ok(VerifiedFinlizedEpochInfosNAPI {
+        root_hash: root_hash.to_vec().into(),
+        epoch_info: epoch_infos
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone().into()))
+            .collect(),
+    })
+}

--- a/src/verify/system/mod.rs
+++ b/src/verify/system/mod.rs
@@ -1,2 +1,3 @@
 pub mod epochs_info;
+pub mod finalized_epoch_infos;
 pub mod total_credits;


### PR DESCRIPTION
# Issue
Sdk require `verifyFinalizedEpochInfosProof` method for new grpc endpoint.

# Things done
- Implemented `verifyFinalizedEpochInfosProof`
- Update ts part
- Bump version