### PR TITLE
Add linux aarch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-wasip1-threads, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-linux-android, x86_64-linux-android, aarch64-apple-ios-sim, aarch64-apple-darwin, x86_64-apple-darwin
+          targets: wasm32-wasip1-threads, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, aarch64-linux-android, x86_64-linux-android, aarch64-apple-ios-sim, aarch64-apple-darwin, x86_64-apple-darwin
           components: rustfmt, rust-src
 
       - name: Cache Rust dependencies
@@ -83,7 +83,7 @@ jobs:
         run: yarn build:full
         env:
           RUSTFLAGS: '-C target-feature=-crt-static'
-          NATIVE_BUILD_TARGET: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-apple-darwin,x86_64-apple-darwin
+          NATIVE_BUILD_TARGET: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,aarch64-apple-darwin,x86_64-apple-darwin
           WASM_TOOLCHAIN: nightly-2026-06-17
 
       - name: Upload build artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-wasip1-threads, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-linux-android, x86_64-linux-android, aarch64-apple-ios-sim, aarch64-apple-darwin, x86_64-apple-darwin
+          targets: wasm32-wasip1-threads, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, aarch64-linux-android, x86_64-linux-android, aarch64-apple-ios-sim, aarch64-apple-darwin, x86_64-apple-darwin
           components: rustfmt, rust-src
 
       - name: Cache Rust dependencies
@@ -81,7 +81,7 @@ jobs:
         run: yarn build:full
         env:
           RUSTFLAGS: '-C target-feature=-crt-static'
-          NATIVE_BUILD_TARGET: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-apple-darwin,x86_64-apple-darwin
+          NATIVE_BUILD_TARGET: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,aarch64-apple-darwin,x86_64-apple-darwin
           WASM_TOOLCHAIN: nightly-2026-06-17
 
       - name: Upload build artifact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "2.0.0-dev.24"
+version = "2.0.0-dev.25"
 dependencies = [
  "async-trait",
  "dpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pshenmic-dpp"
 authors = ["owl352 <kokosinca123@gmail.com>"]
-version = "2.0.0-dev.24"
+version = "2.0.0-dev.25"
 edition = "2024"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "2.0.0-dev.24",
+  "version": "2.0.0-dev.25",
   "main": "dist/src/wasm.js",
   "types": "dist/src/wasm.d.ts",
   "react-native": "./dist/src/react-native.js",


### PR DESCRIPTION
# Issue
Currently pshenmic-dpp doesn't provide binaries for aarch linux 

# Things done
- Updated CI
- bump package version