### PR TITLE
Migrate to dpp v4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -154,38 +154,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
 
 [[package]]
 name = "base16ct"
@@ -321,7 +293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -336,9 +308,9 @@ dependencies = [
  "hkdf",
  "merlin",
  "pairing",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand",
+ "rand_chacha",
+ "rand_core",
  "serde",
  "serde_bare",
  "sha2",
@@ -374,7 +346,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "subtle",
  "zeroize",
@@ -400,12 +372,6 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cbc"
@@ -442,8 +408,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -452,12 +416,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -535,15 +493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,16 +506,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "const-crc32-nostd"
@@ -593,26 +532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -689,7 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.9",
- "rand_core 0.6.4",
+ "rand_core",
  "serdect",
  "subtle",
  "zeroize",
@@ -740,8 +659,8 @@ dependencies = [
 
 [[package]]
 name = "dash-network"
-version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=3d0d5dcd4ad64e2199a726651bca7f8ffac123e6#3d0d5dcd4ad64e2199a726651bca7f8ffac123e6"
+version = "0.45.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=70d4bf8e36057c58e02d56769a6e9760f701dd06#70d4bf8e36057c58e02d56769a6e9760f701dd06"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -751,8 +670,8 @@ dependencies = [
 
 [[package]]
 name = "dashcore"
-version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=3d0d5dcd4ad64e2199a726651bca7f8ffac123e6#3d0d5dcd4ad64e2199a726651bca7f8ffac123e6"
+version = "0.45.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=70d4bf8e36057c58e02d56769a6e9760f701dd06#70d4bf8e36057c58e02d56769a6e9760f701dd06"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -777,13 +696,13 @@ dependencies = [
 
 [[package]]
 name = "dashcore-private"
-version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=3d0d5dcd4ad64e2199a726651bca7f8ffac123e6#3d0d5dcd4ad64e2199a726651bca7f8ffac123e6"
+version = "0.45.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=70d4bf8e36057c58e02d56769a6e9760f701dd06#70d4bf8e36057c58e02d56769a6e9760f701dd06"
 
 [[package]]
 name = "dashcore_hashes"
-version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=3d0d5dcd4ad64e2199a726651bca7f8ffac123e6#3d0d5dcd4ad64e2199a726651bca7f8ffac123e6"
+version = "0.45.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=70d4bf8e36057c58e02d56769a6e9760f701dd06#70d4bf8e36057c58e02d56769a6e9760f701dd06"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -792,8 +711,8 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -857,17 +776,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,8 +786,8 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -909,7 +817,7 @@ dependencies = [
  "platform-value",
  "platform-version",
  "platform-versioning",
- "rand 0.8.5",
+ "rand",
  "regex",
  "serde",
  "serde_json",
@@ -922,8 +830,8 @@ dependencies = [
 
 [[package]]
 name = "dpp-json-convertible-derive"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -932,8 +840,8 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "bincode",
  "byteorder",
@@ -953,12 +861,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ed"
@@ -999,7 +901,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2",
  "subtle",
@@ -1026,7 +928,7 @@ dependencies = [
  "group",
  "hkdf",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "tap",
@@ -1058,15 +960,6 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "env_filter"
@@ -1104,7 +997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1120,7 +1013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "bitvec",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1137,25 +1030,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "fpe"
@@ -1184,7 +1062,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "postcard",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "serdect",
  "thiserror 2.0.17",
@@ -1203,14 +1081,8 @@ dependencies = [
  "document-features",
  "frost-core",
  "hex",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1349,11 +1221,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1381,16 +1251,16 @@ checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "memuse",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "rand_xorshift",
  "subtle",
 ]
 
 [[package]]
 name = "grovedb"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1405,18 +1275,15 @@ dependencies = [
  "grovedb-query",
  "grovedb-version",
  "hex",
- "hex-literal",
  "indexmap 2.13.0",
  "integer-encoding",
- "reqwest",
- "sha2",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "grovedb-bulk-append-tree"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "bincode",
  "blake3",
@@ -1430,8 +1297,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-commitment-tree"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "blake3",
  "grovedb-bulk-append-tree",
@@ -1444,8 +1311,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-costs"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -1454,8 +1321,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-dense-fixed-sized-merkle-tree"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "bincode",
  "blake3",
@@ -1466,8 +1333,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-element"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1480,8 +1347,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "grovedb-costs",
  "hex",
@@ -1492,8 +1359,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-merk"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1514,8 +1381,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-merkle-mountain-range"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "bincode",
  "blake3",
@@ -1524,16 +1391,16 @@ dependencies = [
 
 [[package]]
 name = "grovedb-path"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "hex",
 ]
 
 [[package]]
 name = "grovedb-query"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1546,8 +1413,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-version"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "thiserror 2.0.17",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1555,30 +1422,11 @@ dependencies = [
 
 [[package]]
 name = "grovedb-visualize"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=fc814983d4d36c6ea049642556b9a31ab8d4dfaa#fc814983d4d36c6ea049642556b9a31ab8d4dfaa"
+version = "5.0.1"
+source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
 dependencies = [
  "hex",
  "itertools 0.14.0",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1595,7 +1443,7 @@ dependencies = [
  "halo2_proofs",
  "lazy_static",
  "pasta_curves",
- "rand 0.8.5",
+ "rand",
  "sinsemilla",
  "subtle",
  "uint",
@@ -1632,7 +1480,7 @@ dependencies = [
  "indexmap 1.9.3",
  "maybe-rayon",
  "pasta_curves",
- "rand_core 0.6.4",
+ "rand_core",
  "tracing",
 ]
 
@@ -1721,12 +1569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex-literal"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
-
-[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,108 +1593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hyper"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "pin-utils",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2",
- "system-configuration",
- "tokio",
- "tower-service",
- "tracing",
- "windows-registry",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,108 +1614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
 ]
 
 [[package]]
@@ -2034,22 +1672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,65 +1726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror 2.0.17",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,7 +1745,7 @@ dependencies = [
  "bls12_381",
  "ff",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -2233,12 +1796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
-name = "litemap"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,12 +1815,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maybe-rayon"
@@ -2295,25 +1846,8 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.6.4",
+ "rand_core",
  "zeroize",
-]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mio"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2324,7 +1858,7 @@ checksum = "7ec2ce93a6f06ac6cae04c1da3f2a6a24fcfc1f0eb0b4e0f3d302f0df45326cb"
 dependencies = [
  "ff",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "rustversion",
  "std-shims",
  "zeroize",
@@ -2424,7 +1958,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -2435,7 +1969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -2552,15 +2086,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
 name = "orchard"
 version = "0.14.0"
-source = "git+https://github.com/dashpay/orchard.git?tag=dashified-0.14.0#f05557390a5843bc4eb04c66d8140bc9ef0fe9b7"
+source = "git+https://github.com/dashpay/orchard.git?tag=dashified-0.14.1#38ac9c19a2df7bf3eeadc22ab23053e8fd538828"
 dependencies = [
  "aes",
  "bitvec",
@@ -2579,8 +2107,8 @@ dependencies = [
  "memuse",
  "nonempty",
  "pasta_curves",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "reddsa",
  "serde",
  "sinsemilla",
@@ -2611,16 +2139,10 @@ dependencies = [
  "ff",
  "group",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
  "subtle",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -2646,8 +2168,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "bincode",
  "platform-version",
@@ -2655,8 +2177,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2666,8 +2188,8 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "base64",
  "bincode",
@@ -2676,7 +2198,7 @@ dependencies = [
  "indexmap 2.13.0",
  "platform-serialization",
  "platform-version",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -2685,8 +2207,8 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "bincode",
  "grovedb-version",
@@ -2696,8 +2218,8 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2741,15 +2263,6 @@ dependencies = [
  "embedded-io 0.6.1",
  "heapless 0.7.17",
  "serde",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
 ]
 
 [[package]]
@@ -2810,62 +2323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.17",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.17",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2893,18 +2350,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2914,17 +2361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -2937,21 +2374,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -2987,7 +2415,7 @@ dependencies = [
  "hex",
  "jubjub",
  "pasta_curves",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "thiserror 2.0.17",
  "zeroize",
@@ -3023,60 +2451,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,82 +2475,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
-dependencies = [
- "aws-lc-rs",
- "once_cell",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "web-time",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
-dependencies = [
- "aws-lc-rs",
- "ring",
- "rustls-pki-types",
- "untrusted",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3184,24 +2483,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "scopeguard"
@@ -3230,7 +2511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand",
  "secp256k1-sys",
  "serde",
 ]
@@ -3242,29 +2523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3401,24 +2659,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sinsemilla"
@@ -3436,22 +2678,6 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
 
 [[package]]
 name = "spin"
@@ -3567,47 +2793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3623,7 +2808,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3676,16 +2861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,8 +2877,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3717,35 +2892,7 @@ version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "bytes",
- "libc",
- "mio",
  "pin-project-lite",
- "socket2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -3817,51 +2964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3897,12 +2999,6 @@ name = "treediff"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2ce481b2b7c2534fe7b5242cccebf37f9084392665c6a3783c414a1bada5432"
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -3960,34 +3056,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -4046,30 +3118,11 @@ dependencies = [
  "generic-array 1.3.5",
  "hex",
  "num",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha3",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -4098,19 +3151,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -4143,44 +3183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4225,17 +3227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4255,159 +3246,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4435,8 +3279,8 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "withdrawals-contract"
-version = "4.0.0-rc.2"
-source = "git+https://github.com/dashpay/platform?rev=1ba1ca582882a04cdbeffb834d129c15c7d6cfe9#1ba1ca582882a04cdbeffb834d129c15c7d6cfe9"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?tag=v4.1.0#bfc80249b9257d775d1e5260b8bda47f6fcc8674"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",
@@ -4448,41 +3292,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "synstructure",
 ]
 
 [[package]]
@@ -4493,7 +3308,7 @@ dependencies = [
  "chacha20",
  "chacha20poly1305",
  "cipher",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -4527,27 +3342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4561,39 +3355,6 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "2.0.0-dev.25"
+version = "2.0.0-dev.26"
 dependencies = [
  "async-trait",
  "dpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-dpp = { git = "https://github.com/dashpay/platform", rev = "1ba1ca582882a04cdbeffb834d129c15c7d6cfe9", default-features = false, features = [
+dpp = { git = "https://github.com/dashpay/platform", tag = "v4.1.0", default-features = false, features = [
     "identity-value-conversion",
     "identity-serialization",
     "state-transition-signing",
@@ -17,10 +17,10 @@ dpp = { git = "https://github.com/dashpay/platform", rev = "1ba1ca582882a04cdbef
     "data-contract-json-conversion",
     "shielded-client"
 ] }
-drive = { git = "https://github.com/dashpay/platform", rev = "1ba1ca582882a04cdbeffb834d129c15c7d6cfe9", default-features = false, features = [
+drive = { git = "https://github.com/dashpay/platform", tag = "v4.1.0", default-features = false, features = [
     "verify"
 ] }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "fc814983d4d36c6ea049642556b9a31ab8d4dfaa", features = ["client"] }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", tag = "v5.0.1", features = ["client"] }
 indexmap = "2.0.2"
 # ZIP-32 AccountId for Orchard key derivation from a seed (matches the version
 # the orchard fork uses, so it unifies to a single crate instance).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pshenmic-dpp"
 authors = ["owl352 <kokosinca123@gmail.com>"]
-version = "2.0.0-dev.25"
+version = "2.0.0-dev.26"
 edition = "2024"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "2.0.0-dev.25",
+  "version": "2.0.0-dev.26",
   "main": "dist/src/wasm.js",
   "types": "dist/src/wasm.d.ts",
   "react-native": "./dist/src/react-native.js",

--- a/pkg/src/dpp/structs/Orchard/RecoveredNote.ts
+++ b/pkg/src/dpp/structs/Orchard/RecoveredNote.ts
@@ -17,6 +17,10 @@ export class RecoveredNoteWASM {
     return NoteWASM.createFromRawInstance(this._rawRecoveredNote.note)
   }
 
+  get nullifier (): Uint8Array {
+    return this._rawRecoveredNote.nullifier
+  }
+
   static createFromRawInstance (rawInstance: RecoveredNoteNAPI): RecoveredNoteWASM {
     const instance: RecoveredNoteWASM = Object.create(RecoveredNoteWASM.prototype)
     instance._rawRecoveredNote = rawInstance

--- a/pkg/src/dpp/structs/ShieldedTransitions/IdentityCreateFromShieldedPoolTransition.ts
+++ b/pkg/src/dpp/structs/ShieldedTransitions/IdentityCreateFromShieldedPoolTransition.ts
@@ -1,4 +1,4 @@
-import type { IdentityCreateFromShieldedPoolTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { PlatformVersionNAPI, IdentityCreateFromShieldedPoolTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { IdentityPublicKeyInCreationWASM } from '../IdentityPublicKeyInCreation.js'
 import { SerializedActionWASM } from './SerializedAction.js'
 import { PlatformAddressWASM } from '../PlatformAddress/PlatformAddress.js'
@@ -96,6 +96,14 @@ export class IdentityCreateFromShieldedPoolTransitionWASM {
 
   set identityId (value: IdentifierLike) {
     this._rawIdentityCreateFromShieldedPoolTransition.identityId = prepareIdentifierValue(value)
+  }
+
+  static computeMinimumFee (
+    numActions: number,
+    numKeys: number,
+    platformVersion?: PlatformVersionNAPI
+  ): bigint {
+    return BigInt(dppProvider.dpp.IdentityCreateFromShieldedPoolTransitionNAPI.computeMinimumFee(numActions, numKeys, platformVersion))
   }
 
   toStateTransition (): StateTransitionWASM {

--- a/pkg/src/dpp/structs/ShieldedTransitions/ShieldFromAssetLockTransition.ts
+++ b/pkg/src/dpp/structs/ShieldedTransitions/ShieldFromAssetLockTransition.ts
@@ -1,4 +1,4 @@
-import type { ShieldFromAssetLockTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { PlatformVersionNAPI, ShieldFromAssetLockTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { SerializedActionWASM } from './SerializedAction.js'
 import { AssetLockProofWASM } from '../AssetLockProof/AssetLockProof.js'
 import { PlatformAddressWASM } from '../PlatformAddress/PlatformAddress.js'
@@ -99,6 +99,13 @@ export class ShieldFromAssetLockTransitionWASM {
 
   set signature (value: Uint8Array) {
     this._rawShieldFromAssetLockTransition.signature = value
+  }
+
+  static computeMinimumFee (
+    numActions: number,
+    platformVersion?: PlatformVersionNAPI
+  ): bigint {
+    return BigInt(dppProvider.dpp.ShieldFromAssetLockTransitionNAPI.computeMinimumFee(numActions, platformVersion))
   }
 
   toStateTransition (): StateTransitionWASM {

--- a/pkg/src/dpp/structs/ShieldedTransitions/ShieldTransition.ts
+++ b/pkg/src/dpp/structs/ShieldedTransitions/ShieldTransition.ts
@@ -1,4 +1,4 @@
-import type { ShieldTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { PlatformVersionNAPI, ShieldTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { InputAddressWASM } from '../AddressTransitions/entities/InputAddress.js'
 import { AddressFundsFeeStrategyStepWASM } from '../AddressTransitions/entities/AddressFundsFeeStrategyStep.js'
 import { AddressWitnessWASM } from '../PlatformAddress/AddressWitness.js'
@@ -104,6 +104,13 @@ export class ShieldTransitionWASM {
 
   set inputWitnesses (value: AddressWitnessWASM[]) {
     this._rawShieldTransition.inputWitnesses = value.map(w => w._rawWitness)
+  }
+
+  static computeMinimumFee (
+    numActions: number,
+    platformVersion?: PlatformVersionNAPI
+  ): bigint {
+    return BigInt(dppProvider.dpp.ShieldTransitionNAPI.computeMinimumFee(numActions, platformVersion))
   }
 
   toStateTransition (): StateTransitionWASM {

--- a/pkg/src/dpp/structs/ShieldedTransitions/ShieldedTransferTransition.ts
+++ b/pkg/src/dpp/structs/ShieldedTransitions/ShieldedTransferTransition.ts
@@ -1,4 +1,4 @@
-import type { ShieldedTransferTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { PlatformVersionNAPI, ShieldedTransferTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { SerializedActionWASM } from './SerializedAction.js'
 import { dppProvider } from '../../provider.js'
 import { StateTransitionWASM } from '../StateTransition.js'
@@ -61,6 +61,13 @@ export class ShieldedTransferTransitionWASM {
 
   set bindingsSignature (value: Uint8Array) {
     this._rawShieldedTransferTransition.bindingsSignature = value
+  }
+
+  static computeMinimumFee (
+    numActions: number,
+    platformVersion?: PlatformVersionNAPI
+  ): bigint {
+    return BigInt(dppProvider.dpp.ShieldedTransferTransitionNAPI.computeMinimumFee(numActions, platformVersion))
   }
 
   toStateTransition (): StateTransitionWASM {

--- a/pkg/src/dpp/structs/ShieldedTransitions/ShieldedWithdrawalTransition.ts
+++ b/pkg/src/dpp/structs/ShieldedTransitions/ShieldedWithdrawalTransition.ts
@@ -1,4 +1,4 @@
-import type { ShieldedWithdrawalTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { PlatformVersionNAPI, ShieldedWithdrawalTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { SerializedActionWASM } from './SerializedAction.js'
 import { CoreScriptWASM } from '../CoreScript.js'
 import { PoolingLike } from '../../types.js'
@@ -94,6 +94,13 @@ export class ShieldedWithdrawalTransitionWASM {
 
   set outputScript (value: CoreScriptWASM) {
     this._rawShieldedWithdrawalTransition.outputScript = value._rawCoreScript
+  }
+
+  static computeMinimumFee (
+    numActions: number,
+    platformVersion?: PlatformVersionNAPI
+  ): bigint {
+    return BigInt(dppProvider.dpp.ShieldedWithdrawalTransitionNAPI.computeMinimumFee(numActions, platformVersion))
   }
 
   toStateTransition (): StateTransitionWASM {

--- a/pkg/src/dpp/structs/ShieldedTransitions/UnshieldTransition.ts
+++ b/pkg/src/dpp/structs/ShieldedTransitions/UnshieldTransition.ts
@@ -1,4 +1,4 @@
-import type { UnshieldTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { PlatformVersionNAPI, UnshieldTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { SerializedActionWASM } from './SerializedAction.js'
 import { PlatformAddressWASM } from '../PlatformAddress/PlatformAddress.js'
 import { PlatformAddressLike } from '../../types.js'
@@ -74,6 +74,13 @@ export class UnshieldTransitionWASM {
 
   set bindingsSignature (value: Uint8Array) {
     this._rawUnshieldTransition.bindingsSignature = value
+  }
+
+  static computeMinimumFee (
+    numActions: number,
+    platformVersion?: PlatformVersionNAPI
+  ): bigint {
+    return BigInt(dppProvider.dpp.UnshieldTransitionNAPI.computeMinimumFee(numActions, platformVersion))
   }
 
   toStateTransition (): StateTransitionWASM {

--- a/pkg/src/dpp/types.ts
+++ b/pkg/src/dpp/types.ts
@@ -384,6 +384,12 @@ export type VerifiedStateTransitionResultVariantsRAW =
 export interface VerifiedStateTransitionResult {
   rootHash: Uint8Array
   result: VerifiedStateTransitionResultVariants
+  /**
+   * Whether the proof binds the execution of this specific state transition.
+   * When false, the result is a height-pinned snapshot of the state the
+   * transition affects, not evidence that the transition executed.
+   */
+  isExecutionProved: boolean
 }
 
 export type WhereOperator =

--- a/pkg/src/dpp/verify/StateTransition/verifyStateTransitionResult.ts
+++ b/pkg/src/dpp/verify/StateTransition/verifyStateTransitionResult.ts
@@ -31,6 +31,7 @@ export function verifyStateTransitionResult (
 
   return {
     rootHash: verified.rootHash,
-    result: convertResult(verified.result)
+    result: convertResult(verified.result),
+    isExecutionProved: verified.isExecutionProved
   }
 }

--- a/src/asset_lock_proof/mod.rs
+++ b/src/asset_lock_proof/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     utils::WithJsError,
 };
 use dpp::prelude::AssetLockProof;
+use dpp::{ProtocolError, platform_value};
 use napi::{Either, bindgen_prelude::Uint8Array};
 use napi_derive::napi;
 
@@ -129,9 +130,17 @@ impl AssetLockProofNAPI {
 
     #[napi(js_name = "hex")]
     pub fn to_string(&self) -> Result<String, napi::Error> {
-        Ok(hex::encode(
-            self.0.to_raw_object().with_js_error()?.to_string(),
-        ))
+        // dpp's `AssetLockProof::to_raw_object` is gone; `ValueConvertible::to_object`
+        // is not a drop-in replacement — it serializes the enum, tagging the output
+        // with `$type`. Serialize the inner variant to keep the previous shape.
+        let value = match &self.0 {
+            AssetLockProof::Instant(instant) => platform_value::to_value(instant),
+            AssetLockProof::Chain(chain) => platform_value::to_value(chain),
+        }
+        .map_err(ProtocolError::ValueError)
+        .with_js_error()?;
+
+        Ok(hex::encode(value.to_string()))
         // TODO: Check hex encoding
         // Ok(hex::encode(serde_json::to_string(&self.0).map_err(
         //     |err| napi::Error::new(napi::Status::GenericFailure, err.to_string()),

--- a/src/data_contract/mod.rs
+++ b/src/data_contract/mod.rs
@@ -272,10 +272,13 @@ impl DataContractNAPI {
             false => PlatformVersionNAPI::try_from(js_platform_version)?,
         };
 
-        let value = self
+        let serialization_format: Result<DataContractInSerializationFormat, ProtocolError> = self
             .0
             .clone()
-            .to_value(&platform_version.into())
+            .try_into_platform_versioned(&platform_version.into());
+
+        let value = platform_value::to_value(serialization_format.with_js_error()?)
+            .map_err(ProtocolError::ValueError)
             .with_js_error()?;
 
         value.try_into()
@@ -511,7 +514,14 @@ impl DataContractNAPI {
             false => PlatformVersionNAPI::try_from(js_platform_version)?,
         };
 
-        let json: Value = self.0.to_value(&platform_version.into()).with_js_error()?;
+        let serialization_format: Result<DataContractInSerializationFormat, ProtocolError> = self
+            .0
+            .clone()
+            .try_into_platform_versioned(&platform_version.into());
+
+        let json: Value = platform_value::to_value(serialization_format.with_js_error()?)
+            .map_err(ProtocolError::ValueError)
+            .with_js_error()?;
 
         DynamicValue::try_from(json)
     }

--- a/src/enums/platform_version.rs
+++ b/src/enums/platform_version.rs
@@ -2,7 +2,7 @@ use crate::dynamic_value::DynamicValue;
 use dpp::version::{
     PlatformVersion, v1::PLATFORM_V1, v2::PLATFORM_V2, v3::PLATFORM_V3, v4::PLATFORM_V4,
     v5::PLATFORM_V5, v6::PLATFORM_V6, v7::PLATFORM_V7, v8::PLATFORM_V8, v9::PLATFORM_V9,
-    v10::PLATFORM_V10, v11::PLATFORM_V11, v12::PLATFORM_V12,
+    v10::PLATFORM_V10, v11::PLATFORM_V11, v12::PLATFORM_V12, v13::PLATFORM_V13,
 };
 use napi::Status;
 use napi_derive::napi;
@@ -22,8 +22,9 @@ pub enum PlatformVersionNAPI {
     PLATFORM_V9 = 9,
     PLATFORM_V10 = 10,
     PLATFORM_V11 = 11,
-    #[default]
     PLATFORM_V12 = 12,
+    #[default]
+    PLATFORM_V13 = 13,
 }
 
 impl From<PlatformVersionNAPI> for String {
@@ -41,6 +42,7 @@ impl From<PlatformVersionNAPI> for String {
             PlatformVersionNAPI::PLATFORM_V10 => String::from("PLATFORM_V10"),
             PlatformVersionNAPI::PLATFORM_V11 => String::from("PLATFORM_V11"),
             PlatformVersionNAPI::PLATFORM_V12 => String::from("PLATFORM_V12"),
+            PlatformVersionNAPI::PLATFORM_V13 => String::from("PLATFORM_V13"),
         }
     }
 }
@@ -60,6 +62,7 @@ impl From<PlatformVersionNAPI> for PlatformVersion {
             PlatformVersionNAPI::PLATFORM_V10 => PLATFORM_V10,
             PlatformVersionNAPI::PLATFORM_V11 => PLATFORM_V11,
             PlatformVersionNAPI::PLATFORM_V12 => PLATFORM_V12,
+            PlatformVersionNAPI::PLATFORM_V13 => PLATFORM_V13,
         }
     }
 }
@@ -81,6 +84,7 @@ impl TryFrom<u64> for PlatformVersionNAPI {
             10 => Ok(PlatformVersionNAPI::PLATFORM_V10),
             11 => Ok(PlatformVersionNAPI::PLATFORM_V11),
             12 => Ok(PlatformVersionNAPI::PLATFORM_V12),
+            13 => Ok(PlatformVersionNAPI::PLATFORM_V13),
             _ => Err(napi::Error::new(
                 Status::InvalidArg,
                 format!("unknown platform version value: {}", value),
@@ -106,6 +110,7 @@ impl TryFrom<String> for PlatformVersionNAPI {
             "platform_v10" => Ok(PlatformVersionNAPI::PLATFORM_V10),
             "platform_v11" => Ok(PlatformVersionNAPI::PLATFORM_V11),
             "platform_v12" => Ok(PlatformVersionNAPI::PLATFORM_V12),
+            "platform_v13" => Ok(PlatformVersionNAPI::PLATFORM_V13),
             _ => Err(napi::Error::new(
                 Status::InvalidArg,
                 format!("unknown platform version value: {}", value),

--- a/src/orchard/orchard_address.rs
+++ b/src/orchard/orchard_address.rs
@@ -80,9 +80,7 @@ impl OrchardAddressNAPI {
     #[napi(js_name = "fromBech32m")]
     pub fn from_bech32m(bech32m: String) -> Result<Self, napi::Error> {
         Ok(OrchardAddressNAPI(
-            OrchardAddress::from_bech32m_string(bech32m.as_str())
-                .with_js_error()?
-                .0,
+            OrchardAddress::from_bech32m_string(bech32m.as_str()).with_js_error()?,
         ))
     }
 

--- a/src/orchard/transitions/identity_create_from_shielded_pool.rs
+++ b/src/orchard/transitions/identity_create_from_shielded_pool.rs
@@ -1,5 +1,5 @@
 use dpp::{
-    shielded::SerializedAction,
+    shielded::{SerializedAction, compute_shielded_identity_create_fee},
     state_transition::{
         StateTransition,
         identity_create_from_shielded_pool_transition::{
@@ -9,17 +9,20 @@ use dpp::{
         },
         public_key_in_creation::IdentityPublicKeyInCreation,
     },
+    version::PlatformVersion,
 };
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::{
     dynamic_value::{BigIntString, IdentifierLikeNAPI, PlatformAddressLikeNAPI, TryToU64},
+    enums::platform_version::PlatformVersionNAPI,
     identifier::IdentifierNAPI,
     identity_public_key_in_creation::IdentityPublicKeyInCreationNAPI,
     orchard::serialized_action::SerializedActionNAPI,
     platform_address::PlatformAddressNAPI,
     state_transition::StateTransitionNAPI,
+    utils::{WithJsError, js_bytes_to_anchor, js_bytes_to_binding_signature},
 };
 
 #[derive(Debug, Clone)]
@@ -118,23 +121,17 @@ impl IdentityCreateFromShieldedPoolTransitionNAPI {
 
     #[napi(getter, js_name = "anchor")]
     pub fn anchor(&self) -> Uint8Array {
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(st) => st.anchor.into(),
-        }
+        self.0.anchor().into()
     }
 
     #[napi(getter, js_name = "proof")]
     pub fn proof(&self) -> Uint8Array {
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(st) => st.proof.into(),
-        }
+        self.0.proof().to_vec().into()
     }
 
     #[napi(getter, js_name = "bindingsSignature")]
     pub fn bindings_signature(&self) -> Uint8Array {
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(st) => st.binding_signature.into(),
-        }
+        self.0.binding_signature().into()
     }
 
     #[napi(getter, js_name = "sendToAddressOnCreationFailure")]
@@ -149,66 +146,37 @@ impl IdentityCreateFromShieldedPoolTransitionNAPI {
 
     #[napi(setter, js_name = "publicKeys")]
     pub fn set_public_keys(&mut self, js_public_keys: Vec<&IdentityPublicKeyInCreationNAPI>) {
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(mut st) => {
-                st.public_keys = js_public_keys
-                    .into_iter()
-                    .map(|k| k.clone().into())
-                    .collect()
-            }
-        }
+        self.0.set_public_keys(
+            js_public_keys
+                .into_iter()
+                .map(|k| k.clone().into())
+                .collect(),
+        );
     }
 
     #[napi(setter, js_name = "denomination")]
     pub fn set_denomination(&mut self, denomination: BigIntString) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(mut st) => {
-                st.denomination = denomination.try_to_u64()?;
-                self.0 = IdentityCreateFromShieldedPoolTransition::V0(st);
-            }
-        }
+        self.0.set_denomination(denomination.try_to_u64()?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "actions")]
     pub fn set_actions(&mut self, actions: Vec<&SerializedActionNAPI>) {
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(mut st) => {
-                st.actions = actions.into_iter().map(|a| a.clone().into()).collect();
-                self.0 = IdentityCreateFromShieldedPoolTransition::V0(st);
-            }
-        }
+        self.0
+            .set_actions(actions.into_iter().map(|a| a.clone().into()).collect());
     }
 
     #[napi(setter, js_name = "anchor")]
     pub fn set_anchor(&mut self, js_anchor: Uint8Array) -> Result<(), napi::Error> {
-        if js_anchor.len() != 32 {
-            return Err(napi::Error::new(
-                napi::Status::InvalidArg,
-                "anchor must be 32 bytes length",
-            ));
-        }
-
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(mut st) => {
-                st.anchor = js_anchor.to_vec().try_into().unwrap();
-                self.0 = IdentityCreateFromShieldedPoolTransition::V0(st);
-            }
-        }
+        self.0.set_anchor(js_bytes_to_anchor(js_anchor)?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "proof")]
     pub fn set_proof(&mut self, proof: Uint8Array) {
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(mut st) => {
-                st.proof = proof.to_vec();
-
-                self.0 = IdentityCreateFromShieldedPoolTransition::V0(st)
-            }
-        }
+        self.0.set_proof(proof.to_vec());
     }
 
     #[napi(setter, js_name = "bindingsSignature")]
@@ -216,20 +184,8 @@ impl IdentityCreateFromShieldedPoolTransitionNAPI {
         &mut self,
         js_bindings_signature: Uint8Array,
     ) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(mut st) => {
-                if js_bindings_signature.len() != 64 {
-                    return Err(napi::Error::new(
-                        napi::Status::InvalidArg,
-                        "bindings_signature must be 64 bytes length",
-                    ));
-                }
-
-                st.binding_signature = js_bindings_signature.to_vec().try_into().unwrap();
-
-                self.0 = IdentityCreateFromShieldedPoolTransition::V0(st)
-            }
-        }
+        self.0
+            .set_binding_signature(js_bytes_to_binding_signature(js_bindings_signature)?);
 
         Ok(())
     }
@@ -239,29 +195,36 @@ impl IdentityCreateFromShieldedPoolTransitionNAPI {
         &mut self,
         js_address: PlatformAddressLikeNAPI,
     ) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(mut st) => {
-                st.send_to_address_on_creation_failure =
-                    PlatformAddressNAPI::try_from(js_address)?.into();
-
-                self.0 = IdentityCreateFromShieldedPoolTransition::V0(st)
-            }
-        }
+        self.0.set_send_to_address_on_creation_failure(
+            PlatformAddressNAPI::try_from(js_address)?.into(),
+        );
 
         Ok(())
     }
 
     #[napi(setter, js_name = "identityId")]
     pub fn set_identity_id(&mut self, js_id: IdentifierLikeNAPI) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            IdentityCreateFromShieldedPoolTransition::V0(mut st) => {
-                st.identity_id = IdentifierNAPI::try_from(js_id)?.into();
-
-                self.0 = IdentityCreateFromShieldedPoolTransition::V0(st)
-            }
-        }
+        self.0
+            .set_identity_id(IdentifierNAPI::try_from(js_id)?.into());
 
         Ok(())
+    }
+
+    #[napi(js_name = "computeMinimumFee")]
+    pub fn compute_minimum_fee(
+        js_num_actions: u32,
+        js_num_keys: u32,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        compute_shielded_identity_create_fee(
+            js_num_actions as usize,
+            js_num_keys as usize,
+            &platform_version,
+        )
+        .map(BigIntString::from_u64)
+        .with_js_error()
     }
 
     #[napi(js_name = "toStateTransition")]

--- a/src/orchard/transitions/shield_from_asset_lock.rs
+++ b/src/orchard/transitions/shield_from_asset_lock.rs
@@ -2,13 +2,15 @@ use dpp::{
     address_funds::PlatformAddress,
     identity::state_transition::AssetLockProved,
     platform_value::BinaryData,
-    shielded::SerializedAction,
+    shielded::{SerializedAction, compute_minimum_shielded_fee},
     state_transition::{
-        StateTransition,
+        StateTransition, StateTransitionSingleSigned,
         shield_from_asset_lock_transition::{
-            ShieldFromAssetLockTransition, v0::ShieldFromAssetLockTransitionV0,
+            ShieldFromAssetLockTransition, accessors::ShieldFromAssetLockTransitionAccessorsV0,
+            v0::ShieldFromAssetLockTransitionV0,
         },
     },
+    version::PlatformVersion,
 };
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
@@ -16,10 +18,11 @@ use napi_derive::napi;
 use crate::{
     asset_lock_proof::AssetLockProofNAPI,
     dynamic_value::{BigIntString, PlatformAddressLikeNAPI, TryToU64},
+    enums::platform_version::PlatformVersionNAPI,
     orchard::serialized_action::SerializedActionNAPI,
     platform_address::PlatformAddressNAPI,
     state_transition::StateTransitionNAPI,
-    utils::WithJsError,
+    utils::{WithJsError, js_bytes_to_anchor, js_bytes_to_binding_signature},
 };
 
 #[derive(Debug, Clone)]
@@ -95,53 +98,37 @@ impl ShieldFromAssetLockTransitionNAPI {
 
     #[napi(getter, js_name = "actions")]
     pub fn actions(&self) -> Vec<SerializedActionNAPI> {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(st) => {
-                st.actions.iter().map(|t| t.clone().into()).collect()
-            }
-        }
+        self.0.actions().iter().map(|t| t.clone().into()).collect()
     }
 
     #[napi(getter, js_name = "valueBalance")]
     pub fn value_balance(&self) -> BigIntString {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(st) => BigIntString::from_u64(st.value_balance),
-        }
+        BigIntString::from_u64(self.0.value_balance())
     }
 
     #[napi(getter, js_name = "anchor")]
     pub fn anchor(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(st) => st.anchor.into(),
-        }
+        self.0.anchor().into()
     }
 
     #[napi(getter, js_name = "proof")]
     pub fn proof(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(st) => st.proof.into(),
-        }
+        self.0.proof().to_vec().into()
     }
 
     #[napi(getter, js_name = "bindingsSignature")]
     pub fn bindings_signature(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(st) => st.binding_signature.into(),
-        }
+        self.0.binding_signature().into()
     }
 
     #[napi(getter, js_name = "surplusOutput")]
     pub fn surplus_output(&self) -> Option<PlatformAddressNAPI> {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(st) => st.surplus_output.map(Into::into),
-        }
+        self.0.surplus_output().cloned().map(Into::into)
     }
 
     #[napi(getter, js_name = "signature")]
     pub fn signature(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(st) => st.signature.to_vec().into(),
-        }
+        self.0.signature().to_vec().into()
     }
 
     #[napi(setter, js_name = "assetLockProof")]
@@ -158,54 +145,27 @@ impl ShieldFromAssetLockTransitionNAPI {
 
     #[napi(setter, js_name = "actions")]
     pub fn set_actions(&mut self, actions: Vec<&SerializedActionNAPI>) {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(mut st) => {
-                st.actions = actions.into_iter().map(|a| a.clone().into()).collect();
-                self.0 = ShieldFromAssetLockTransition::V0(st);
-            }
-        }
+        self.0
+            .set_actions(actions.into_iter().map(|a| a.clone().into()).collect());
     }
 
     #[napi(setter, js_name = "valueBalance")]
     pub fn set_value_balance(&mut self, amount: BigIntString) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(mut st) => {
-                st.value_balance = amount.try_to_u64()?;
-                self.0 = ShieldFromAssetLockTransition::V0(st);
-            }
-        }
+        self.0.set_value_balance(amount.try_to_u64()?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "anchor")]
     pub fn set_anchor(&mut self, js_anchor: Uint8Array) -> Result<(), napi::Error> {
-        if js_anchor.len() != 32 {
-            return Err(napi::Error::new(
-                napi::Status::InvalidArg,
-                "anchor must be 32 bytes length",
-            ));
-        }
-
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(mut st) => {
-                st.anchor = js_anchor.to_vec().try_into().unwrap();
-                self.0 = ShieldFromAssetLockTransition::V0(st);
-            }
-        }
+        self.0.set_anchor(js_bytes_to_anchor(js_anchor)?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "proof")]
     pub fn set_proof(&mut self, proof: Uint8Array) {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(mut st) => {
-                st.proof = proof.to_vec();
-
-                self.0 = ShieldFromAssetLockTransition::V0(st)
-            }
-        }
+        self.0.set_proof(proof.to_vec());
     }
 
     #[napi(setter, js_name = "bindingsSignature")]
@@ -213,20 +173,8 @@ impl ShieldFromAssetLockTransitionNAPI {
         &mut self,
         js_bindings_signature: Uint8Array,
     ) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(mut st) => {
-                if js_bindings_signature.len() != 64 {
-                    return Err(napi::Error::new(
-                        napi::Status::InvalidArg,
-                        "bindings_signature must be 64 bytes length",
-                    ));
-                }
-
-                st.binding_signature = js_bindings_signature.to_vec().try_into().unwrap();
-
-                self.0 = ShieldFromAssetLockTransition::V0(st)
-            }
-        }
+        self.0
+            .set_binding_signature(js_bytes_to_binding_signature(js_bindings_signature)?);
 
         Ok(())
     }
@@ -236,28 +184,31 @@ impl ShieldFromAssetLockTransitionNAPI {
         &mut self,
         js_surplus_output: Option<PlatformAddressLikeNAPI>,
     ) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(mut st) => {
-                st.surplus_output = js_surplus_output
-                    .map(PlatformAddressNAPI::try_from)
-                    .transpose()?
-                    .map(Into::into);
-
-                self.0 = ShieldFromAssetLockTransition::V0(st)
-            }
-        }
+        self.0.set_surplus_output(
+            js_surplus_output
+                .map(PlatformAddressNAPI::try_from)
+                .transpose()?
+                .map(Into::into),
+        );
 
         Ok(())
     }
 
     #[napi(setter, js_name = "signature")]
     pub fn set_signature(&mut self, signature: Uint8Array) {
-        match self.0.clone() {
-            ShieldFromAssetLockTransition::V0(mut st) => {
-                st.signature = BinaryData::new(signature.to_vec());
-                self.0 = ShieldFromAssetLockTransition::V0(st);
-            }
-        }
+        self.0.set_signature(BinaryData::new(signature.to_vec()));
+    }
+
+    #[napi(js_name = "computeMinimumFee")]
+    pub fn compute_minimum_fee(
+        js_num_actions: u32,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        compute_minimum_shielded_fee(js_num_actions as usize, &platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "toStateTransition")]

--- a/src/orchard/transitions/shield_transition.rs
+++ b/src/orchard/transitions/shield_transition.rs
@@ -1,10 +1,13 @@
 use dpp::{
     address_funds::{AddressFundsFeeStrategyStep, AddressWitness},
-    shielded::SerializedAction,
+    shielded::{SerializedAction, compute_shielded_verification_fee},
     state_transition::{
         StateTransition, StateTransitionHasUserFeeIncrease, StateTransitionWitnessSigned,
-        shield_transition::{ShieldTransition, v0::ShieldTransitionV0},
+        shield_transition::{
+            ShieldTransition, accessors::ShieldTransitionAccessorsV0, v0::ShieldTransitionV0,
+        },
     },
+    version::PlatformVersion,
 };
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
@@ -14,10 +17,11 @@ use crate::{
         address_funds_fee_step::AddressFundsFeeStrategyStepNAPI, input_address::InputAddressNAPI,
     },
     dynamic_value::{BigIntString, TryToU64},
+    enums::platform_version::PlatformVersionNAPI,
     orchard::serialized_action::SerializedActionNAPI,
     platform_address::address_witness::AddressWitnessNAPI,
     state_transition::StateTransitionNAPI,
-    utils::js_inputs_to_inputs,
+    utils::{WithJsError, js_bytes_to_anchor, js_bytes_to_binding_signature, js_inputs_to_inputs},
 };
 
 #[derive(Debug, Clone)]
@@ -107,56 +111,36 @@ impl ShieldTransitionNAPI {
 
     #[napi(getter, js_name = "actions")]
     pub fn actions(&self) -> Vec<SerializedActionNAPI> {
-        match self.0.clone() {
-            ShieldTransition::V0(shield_transition_v0) => shield_transition_v0
-                .actions
-                .iter()
-                .map(|t| t.clone().into())
-                .collect(),
-        }
+        self.0.actions().iter().map(|t| t.clone().into()).collect()
     }
 
     #[napi(getter, js_name = "amount")]
     pub fn amount(&self) -> BigIntString {
-        match self.0.clone() {
-            ShieldTransition::V0(shield_transition_v0) => {
-                BigIntString::from_u64(shield_transition_v0.amount)
-            }
-        }
+        BigIntString::from_u64(self.0.amount())
     }
 
     #[napi(getter, js_name = "anchor")]
     pub fn anchor(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldTransition::V0(shield_transition_v0) => shield_transition_v0.anchor.into(),
-        }
+        self.0.anchor().into()
     }
 
     #[napi(getter, js_name = "proof")]
     pub fn proof(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldTransition::V0(shield_transition_v0) => shield_transition_v0.proof.into(),
-        }
+        self.0.proof().to_vec().into()
     }
 
     #[napi(getter, js_name = "bindingsSignature")]
     pub fn bindings_signature(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldTransition::V0(shield_transition_v0) => {
-                shield_transition_v0.binding_signature.into()
-            }
-        }
+        self.0.binding_signature().into()
     }
 
     #[napi(getter, js_name = "feeStrategy")]
     pub fn fee_strategy(&self) -> Vec<AddressFundsFeeStrategyStepNAPI> {
-        match self.0.clone() {
-            ShieldTransition::V0(shield_transition_v0) => shield_transition_v0
-                .fee_strategy
-                .iter()
-                .map(|s| s.clone().into())
-                .collect(),
-        }
+        self.0
+            .fee_strategy()
+            .iter()
+            .map(|s| s.clone().into())
+            .collect()
     }
 
     #[napi(getter, js_name = "userFeeIncrease")]
@@ -181,55 +165,27 @@ impl ShieldTransitionNAPI {
 
     #[napi(setter, js_name = "actions")]
     pub fn set_actions(&mut self, actions: Vec<&SerializedActionNAPI>) {
-        match self.0.clone() {
-            ShieldTransition::V0(mut shield_transition_v0) => {
-                shield_transition_v0.actions =
-                    actions.into_iter().map(|a| a.clone().into()).collect();
-                self.0 = ShieldTransition::V0(shield_transition_v0);
-            }
-        }
+        self.0
+            .set_actions(actions.into_iter().map(|a| a.clone().into()).collect());
     }
 
     #[napi(setter, js_name = "amount")]
     pub fn set_amount(&mut self, amount: BigIntString) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            ShieldTransition::V0(mut shield_transition_v0) => {
-                shield_transition_v0.amount = amount.try_to_u64()?;
-                self.0 = ShieldTransition::V0(shield_transition_v0);
-            }
-        }
+        self.0.set_amount(amount.try_to_u64()?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "anchor")]
     pub fn set_anchor(&mut self, js_anchor: Uint8Array) -> Result<(), napi::Error> {
-        if js_anchor.len() != 32 {
-            return Err(napi::Error::new(
-                napi::Status::InvalidArg,
-                "anchor must be 32 bytes length",
-            ));
-        }
-
-        match self.0.clone() {
-            ShieldTransition::V0(mut shield_transition_v0) => {
-                shield_transition_v0.anchor = js_anchor.to_vec().try_into().unwrap();
-                self.0 = ShieldTransition::V0(shield_transition_v0);
-            }
-        }
+        self.0.set_anchor(js_bytes_to_anchor(js_anchor)?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "proof")]
     pub fn set_proof(&mut self, proof: Uint8Array) {
-        match self.0.clone() {
-            ShieldTransition::V0(mut shield_transition_v0) => {
-                shield_transition_v0.proof = proof.to_vec();
-
-                self.0 = ShieldTransition::V0(shield_transition_v0)
-            }
-        }
+        self.0.set_proof(proof.to_vec());
     }
 
     #[napi(setter, js_name = "bindingsSignature")]
@@ -237,35 +193,16 @@ impl ShieldTransitionNAPI {
         &mut self,
         js_bindings_signature: Uint8Array,
     ) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            ShieldTransition::V0(mut shield_transition_v0) => {
-                if js_bindings_signature.len() != 64 {
-                    return Err(napi::Error::new(
-                        napi::Status::InvalidArg,
-                        "bindings_signature must be 64 bytes length",
-                    ));
-                }
-
-                shield_transition_v0.binding_signature =
-                    js_bindings_signature.to_vec().try_into().unwrap();
-
-                self.0 = ShieldTransition::V0(shield_transition_v0)
-            }
-        }
+        self.0
+            .set_binding_signature(js_bytes_to_binding_signature(js_bindings_signature)?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "feeStrategy")]
     pub fn set_fee_strategy(&mut self, fee_strategy: Vec<&AddressFundsFeeStrategyStepNAPI>) {
-        match self.0.clone() {
-            ShieldTransition::V0(mut shield_transition_v0) => {
-                shield_transition_v0.fee_strategy =
-                    fee_strategy.into_iter().map(|s| s.clone().into()).collect();
-
-                self.0 = ShieldTransition::V0(shield_transition_v0);
-            }
-        }
+        self.0
+            .set_fee_strategy(fee_strategy.into_iter().map(|s| s.clone().into()).collect());
     }
 
     #[napi(setter, js_name = "userFeeIncrease")]
@@ -281,6 +218,18 @@ impl ShieldTransitionNAPI {
                 .map(|w| w.clone().into())
                 .collect(),
         )
+    }
+
+    #[napi(js_name = "computeMinimumFee")]
+    pub fn compute_minimum_fee(
+        js_num_actions: u32,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        compute_shielded_verification_fee(js_num_actions as usize, &platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "toStateTransition")]

--- a/src/orchard/transitions/shielded_transfer_transition.rs
+++ b/src/orchard/transitions/shielded_transfer_transition.rs
@@ -1,5 +1,5 @@
 use dpp::{
-    shielded::SerializedAction,
+    shielded::{SerializedAction, compute_minimum_shielded_fee},
     state_transition::{
         StateTransition,
         shielded_transfer_transition::{
@@ -7,14 +7,17 @@ use dpp::{
             v0::ShieldedTransferTransitionV0,
         },
     },
+    version::PlatformVersion,
 };
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::{
     dynamic_value::{BigIntString, TryToU64},
+    enums::platform_version::PlatformVersionNAPI,
     orchard::serialized_action::SerializedActionNAPI,
     state_transition::StateTransitionNAPI,
+    utils::{WithJsError, js_bytes_to_anchor, js_bytes_to_binding_signature},
 };
 
 #[derive(Debug, Clone)]
@@ -80,82 +83,47 @@ impl ShieldedTransferTransitionNAPI {
 
     #[napi(getter, js_name = "valueBalance")]
     pub fn value_balance(&self) -> BigIntString {
-        match self.0.clone() {
-            ShieldedTransferTransition::V0(st) => BigIntString::from_u64(st.value_balance),
-        }
+        BigIntString::from_u64(self.0.value_balance())
     }
 
     #[napi(getter, js_name = "anchor")]
     pub fn anchor(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldedTransferTransition::V0(st) => st.anchor.into(),
-        }
+        self.0.anchor().into()
     }
 
     #[napi(getter, js_name = "proof")]
     pub fn proof(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldedTransferTransition::V0(st) => st.proof.into(),
-        }
+        self.0.proof().to_vec().into()
     }
 
     #[napi(getter, js_name = "bindingsSignature")]
     pub fn bindings_signature(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldedTransferTransition::V0(st) => st.binding_signature.into(),
-        }
+        self.0.binding_signature().into()
     }
 
     #[napi(setter, js_name = "actions")]
     pub fn set_actions(&mut self, actions: Vec<&SerializedActionNAPI>) {
-        match self.0.clone() {
-            ShieldedTransferTransition::V0(mut st) => {
-                st.actions = actions.into_iter().map(|a| a.clone().into()).collect();
-                self.0 = ShieldedTransferTransition::V0(st);
-            }
-        }
+        self.0
+            .set_actions(actions.into_iter().map(|a| a.clone().into()).collect());
     }
 
     #[napi(setter, js_name = "valueBalance")]
     pub fn set_amount(&mut self, amount: BigIntString) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            ShieldedTransferTransition::V0(mut st) => {
-                st.value_balance = amount.try_to_u64()?;
-                self.0 = ShieldedTransferTransition::V0(st);
-            }
-        }
+        self.0.set_value_balance(amount.try_to_u64()?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "anchor")]
     pub fn set_anchor(&mut self, js_anchor: Uint8Array) -> Result<(), napi::Error> {
-        if js_anchor.len() != 32 {
-            return Err(napi::Error::new(
-                napi::Status::InvalidArg,
-                "anchor must be 32 bytes length",
-            ));
-        }
-
-        match self.0.clone() {
-            ShieldedTransferTransition::V0(mut st) => {
-                st.anchor = js_anchor.to_vec().try_into().unwrap();
-                self.0 = ShieldedTransferTransition::V0(st)
-            }
-        }
+        self.0.set_anchor(js_bytes_to_anchor(js_anchor)?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "proof")]
     pub fn set_proof(&mut self, proof: Uint8Array) {
-        match self.0.clone() {
-            ShieldedTransferTransition::V0(mut st) => {
-                st.proof = proof.to_vec();
-
-                self.0 = ShieldedTransferTransition::V0(st)
-            }
-        }
+        self.0.set_proof(proof.to_vec());
     }
 
     #[napi(setter, js_name = "bindingsSignature")]
@@ -163,22 +131,22 @@ impl ShieldedTransferTransitionNAPI {
         &mut self,
         js_bindings_signature: Uint8Array,
     ) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            ShieldedTransferTransition::V0(mut st) => {
-                if js_bindings_signature.len() != 64 {
-                    return Err(napi::Error::new(
-                        napi::Status::InvalidArg,
-                        "bindings_signature must be 64 bytes length",
-                    ));
-                }
-
-                st.binding_signature = js_bindings_signature.to_vec().try_into().unwrap();
-
-                self.0 = ShieldedTransferTransition::V0(st)
-            }
-        }
+        self.0
+            .set_binding_signature(js_bytes_to_binding_signature(js_bindings_signature)?);
 
         Ok(())
+    }
+
+    #[napi(js_name = "computeMinimumFee")]
+    pub fn compute_minimum_fee(
+        js_num_actions: u32,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        compute_minimum_shielded_fee(js_num_actions as usize, &platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "toStateTransition")]

--- a/src/orchard/transitions/shielded_withdrawal.rs
+++ b/src/orchard/transitions/shielded_withdrawal.rs
@@ -1,5 +1,5 @@
 use dpp::{
-    shielded::SerializedAction,
+    shielded::{SerializedAction, compute_shielded_withdrawal_fee},
     state_transition::{
         StateTransition,
         shielded_withdrawal_transition::{
@@ -7,6 +7,7 @@ use dpp::{
             v0::ShieldedWithdrawalTransitionV0,
         },
     },
+    version::PlatformVersion,
 };
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
@@ -14,9 +15,10 @@ use napi_derive::napi;
 use crate::{
     core_script::CoreScriptNAPI,
     dynamic_value::{BigIntString, DynamicValue, TryToU64},
-    enums::pooling::PoolingNAPI,
+    enums::{platform_version::PlatformVersionNAPI, pooling::PoolingNAPI},
     orchard::serialized_action::SerializedActionNAPI,
     state_transition::StateTransitionNAPI,
+    utils::{WithJsError, js_bytes_to_anchor, js_bytes_to_binding_signature},
 };
 
 #[derive(Debug, Clone)]
@@ -90,44 +92,32 @@ impl ShieldedWithdrawalTransitionNAPI {
 
     #[napi(getter, js_name = "unshieldingAmount")]
     pub fn unshielding_amount(&self) -> BigIntString {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(st) => BigIntString::from_u64(st.unshielding_amount),
-        }
+        BigIntString::from_u64(self.0.unshielding_amount())
     }
 
     #[napi(getter, js_name = "anchor")]
     pub fn anchor(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(st) => st.anchor.into(),
-        }
+        self.0.anchor().into()
     }
 
     #[napi(getter, js_name = "proof")]
     pub fn proof(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(st) => st.proof.into(),
-        }
+        self.0.proof().to_vec().into()
     }
 
     #[napi(getter, js_name = "bindingsSignature")]
     pub fn bindings_signature(&self) -> Uint8Array {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(st) => st.binding_signature.into(),
-        }
+        self.0.binding_signature().into()
     }
 
     #[napi(getter, js_name = "coreFeePerByte")]
     pub fn core_fee_per_byte(&self) -> u32 {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(st) => st.core_fee_per_byte,
-        }
+        self.0.core_fee_per_byte()
     }
 
     #[napi(getter, js_name = "pooling")]
     pub fn pooling(&self) -> String {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(st) => PoolingNAPI::from(st.pooling).into(),
-        }
+        PoolingNAPI::from(self.0.pooling()).into()
     }
 
     #[napi(getter, js_name = "outputScript")]
@@ -137,54 +127,27 @@ impl ShieldedWithdrawalTransitionNAPI {
 
     #[napi(setter, js_name = "actions")]
     pub fn set_actions(&mut self, actions: Vec<&SerializedActionNAPI>) {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(mut st) => {
-                st.actions = actions.into_iter().map(|a| a.clone().into()).collect();
-                self.0 = ShieldedWithdrawalTransition::V0(st);
-            }
-        }
+        self.0
+            .set_actions(actions.into_iter().map(|a| a.clone().into()).collect());
     }
 
     #[napi(setter, js_name = "unshieldingAmount")]
     pub fn set_unshielding_amount(&mut self, amount: BigIntString) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(mut st) => {
-                st.unshielding_amount = amount.try_to_u64()?;
-                self.0 = ShieldedWithdrawalTransition::V0(st);
-            }
-        }
+        self.0.set_unshielding_amount(amount.try_to_u64()?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "anchor")]
     pub fn set_anchor(&mut self, js_anchor: Uint8Array) -> Result<(), napi::Error> {
-        if js_anchor.len() != 32 {
-            return Err(napi::Error::new(
-                napi::Status::InvalidArg,
-                "anchor must be 32 bytes length",
-            ));
-        }
-
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(mut st) => {
-                st.anchor = js_anchor.to_vec().try_into().unwrap();
-                self.0 = ShieldedWithdrawalTransition::V0(st);
-            }
-        }
+        self.0.set_anchor(js_bytes_to_anchor(js_anchor)?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "proof")]
     pub fn set_proof(&mut self, proof: Uint8Array) {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(mut st) => {
-                st.proof = proof.to_vec();
-
-                self.0 = ShieldedWithdrawalTransition::V0(st)
-            }
-        }
+        self.0.set_proof(proof.to_vec());
     }
 
     #[napi(setter, js_name = "bindingsSignature")]
@@ -192,58 +155,40 @@ impl ShieldedWithdrawalTransitionNAPI {
         &mut self,
         js_bindings_signature: Uint8Array,
     ) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(mut st) => {
-                if js_bindings_signature.len() != 64 {
-                    return Err(napi::Error::new(
-                        napi::Status::InvalidArg,
-                        "bindings_signature must be 64 bytes length",
-                    ));
-                }
-
-                st.binding_signature = js_bindings_signature.to_vec().try_into().unwrap();
-
-                self.0 = ShieldedWithdrawalTransition::V0(st)
-            }
-        }
+        self.0
+            .set_binding_signature(js_bytes_to_binding_signature(js_bindings_signature)?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "coreFeePerByte")]
     pub fn set_core_fee_per_byte(&mut self, core_fee_per_byte: u32) {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(mut st) => {
-                st.core_fee_per_byte = core_fee_per_byte;
-
-                self.0 = ShieldedWithdrawalTransition::V0(st)
-            }
-        }
+        self.0.set_core_fee_per_byte(core_fee_per_byte);
     }
 
     #[napi(setter, js_name = "pooling")]
     pub fn set_pooling(&mut self, js_pooling: &DynamicValue) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(mut st) => {
-                let pooling = PoolingNAPI::try_from(js_pooling)?;
-                st.pooling = pooling.into();
-
-                self.0 = ShieldedWithdrawalTransition::V0(st)
-            }
-        }
+        self.0
+            .set_pooling(PoolingNAPI::try_from(js_pooling)?.into());
 
         Ok(())
     }
 
     #[napi(setter, js_name = "outputScript")]
     pub fn set_output_script(&mut self, output_script: &CoreScriptNAPI) {
-        match self.0.clone() {
-            ShieldedWithdrawalTransition::V0(mut st) => {
-                st.output_script = output_script.clone().into();
+        self.0.set_output_script(output_script.clone().into());
+    }
 
-                self.0 = ShieldedWithdrawalTransition::V0(st)
-            }
-        }
+    #[napi(js_name = "computeMinimumFee")]
+    pub fn compute_minimum_fee(
+        js_num_actions: u32,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        compute_shielded_withdrawal_fee(js_num_actions as usize, &platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "toStateTransition")]

--- a/src/orchard/transitions/unshield_transition.rs
+++ b/src/orchard/transitions/unshield_transition.rs
@@ -1,21 +1,24 @@
 use dpp::{
     address_funds::PlatformAddress,
-    shielded::SerializedAction,
+    shielded::{SerializedAction, compute_shielded_unshield_fee},
     state_transition::{
         StateTransition,
         unshield_transition::{
             UnshieldTransition, accessors::UnshieldTransitionAccessorsV0, v0::UnshieldTransitionV0,
         },
     },
+    version::PlatformVersion,
 };
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::{
     dynamic_value::{BigIntString, PlatformAddressLikeNAPI, TryToU64},
+    enums::platform_version::PlatformVersionNAPI,
     orchard::serialized_action::SerializedActionNAPI,
     platform_address::PlatformAddressNAPI,
     state_transition::StateTransitionNAPI,
+    utils::{WithJsError, js_bytes_to_anchor, js_bytes_to_binding_signature},
 };
 
 #[derive(Debug, Clone)]
@@ -89,30 +92,22 @@ impl UnshieldTransitionNAPI {
 
     #[napi(getter, js_name = "unshieldingAmount")]
     pub fn unshielding_amount(&self) -> BigIntString {
-        match self.0.clone() {
-            UnshieldTransition::V0(st) => BigIntString::from_u64(st.unshielding_amount),
-        }
+        BigIntString::from_u64(self.0.unshielding_amount())
     }
 
     #[napi(getter, js_name = "anchor")]
     pub fn anchor(&self) -> Uint8Array {
-        match self.0.clone() {
-            UnshieldTransition::V0(st) => st.anchor.into(),
-        }
+        self.0.anchor().into()
     }
 
     #[napi(getter, js_name = "proof")]
     pub fn proof(&self) -> Uint8Array {
-        match self.0.clone() {
-            UnshieldTransition::V0(st) => st.proof.into(),
-        }
+        self.0.proof().to_vec().into()
     }
 
     #[napi(getter, js_name = "bindingsSignature")]
     pub fn bindings_signature(&self) -> Uint8Array {
-        match self.0.clone() {
-            UnshieldTransition::V0(st) => st.binding_signature.into(),
-        }
+        self.0.binding_signature().into()
     }
 
     #[napi(setter, js_name = "outputAddress")]
@@ -120,66 +115,35 @@ impl UnshieldTransitionNAPI {
         &mut self,
         js_output_address: PlatformAddressLikeNAPI,
     ) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            UnshieldTransition::V0(mut st) => {
-                st.output_address = PlatformAddressNAPI::try_from(js_output_address)?.into();
-                self.0 = UnshieldTransition::V0(st)
-            }
-        }
+        self.0
+            .set_output_address(PlatformAddressNAPI::try_from(js_output_address)?.into());
 
         Ok(())
     }
 
     #[napi(setter, js_name = "actions")]
     pub fn set_actions(&mut self, actions: Vec<&SerializedActionNAPI>) {
-        match self.0.clone() {
-            UnshieldTransition::V0(mut st) => {
-                st.actions = actions.into_iter().map(|a| a.clone().into()).collect();
-                self.0 = UnshieldTransition::V0(st);
-            }
-        }
+        self.0
+            .set_actions(actions.into_iter().map(|a| a.clone().into()).collect());
     }
 
     #[napi(setter, js_name = "unshieldingAmount")]
     pub fn set_unshielding_amount(&mut self, amount: BigIntString) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            UnshieldTransition::V0(mut st) => {
-                st.unshielding_amount = amount.try_to_u64()?;
-                self.0 = UnshieldTransition::V0(st);
-            }
-        }
+        self.0.set_unshielding_amount(amount.try_to_u64()?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "anchor")]
     pub fn set_anchor(&mut self, js_anchor: Uint8Array) -> Result<(), napi::Error> {
-        if js_anchor.len() != 32 {
-            return Err(napi::Error::new(
-                napi::Status::InvalidArg,
-                "anchor must be 32 bytes length",
-            ));
-        }
-
-        match self.0.clone() {
-            UnshieldTransition::V0(mut st) => {
-                st.anchor = js_anchor.to_vec().try_into().unwrap();
-                self.0 = UnshieldTransition::V0(st);
-            }
-        }
+        self.0.set_anchor(js_bytes_to_anchor(js_anchor)?);
 
         Ok(())
     }
 
     #[napi(setter, js_name = "proof")]
     pub fn set_proof(&mut self, proof: Uint8Array) {
-        match self.0.clone() {
-            UnshieldTransition::V0(mut st) => {
-                st.proof = proof.to_vec();
-
-                self.0 = UnshieldTransition::V0(st)
-            }
-        }
+        self.0.set_proof(proof.to_vec());
     }
 
     #[napi(setter, js_name = "bindingsSignature")]
@@ -187,22 +151,22 @@ impl UnshieldTransitionNAPI {
         &mut self,
         js_bindings_signature: Uint8Array,
     ) -> Result<(), napi::Error> {
-        match self.0.clone() {
-            UnshieldTransition::V0(mut st) => {
-                if js_bindings_signature.len() != 64 {
-                    return Err(napi::Error::new(
-                        napi::Status::InvalidArg,
-                        "bindings_signature must be 64 bytes length",
-                    ));
-                }
-
-                st.binding_signature = js_bindings_signature.to_vec().try_into().unwrap();
-
-                self.0 = UnshieldTransition::V0(st)
-            }
-        }
+        self.0
+            .set_binding_signature(js_bytes_to_binding_signature(js_bindings_signature)?);
 
         Ok(())
+    }
+
+    #[napi(js_name = "computeMinimumFee")]
+    pub fn compute_minimum_fee(
+        js_num_actions: u32,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        compute_shielded_unshield_fee(js_num_actions as usize, &platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "toStateTransition")]

--- a/src/platform_address/mod.rs
+++ b/src/platform_address/mod.rs
@@ -92,9 +92,7 @@ impl PlatformAddressNAPI {
     #[napi(js_name = "fromBech32m")]
     pub fn from_bech32m(bech32m: String) -> Result<Self, napi::Error> {
         Ok(PlatformAddressNAPI(
-            PlatformAddress::from_bech32m_string(bech32m.as_str())
-                .with_js_error()?
-                .0,
+            PlatformAddress::from_bech32m_string(bech32m.as_str()).with_js_error()?,
         ))
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,6 +14,7 @@ use dpp::{
     ProtocolError, platform_value::Value, prelude::Identifier, util::hash::hash_double_to_vec,
 };
 use napi::Status;
+use napi::bindgen_prelude::Uint8Array;
 
 use crate::dynamic_value::DynamicValue;
 
@@ -128,4 +129,26 @@ pub fn js_outputs_to_outputs(
             ))
         })
         .collect::<Result<BTreeMap<PlatformAddress, Credits>, napi::Error>>()
+}
+
+/// Convert a JS byte array into an Orchard anchor, rejecting the wrong length
+/// instead of panicking on the `TryInto`.
+pub fn js_bytes_to_anchor(js_anchor: Uint8Array) -> Result<[u8; 32], napi::Error> {
+    js_anchor
+        .to_vec()
+        .try_into()
+        .map_err(|_| napi::Error::new(Status::InvalidArg, "anchor must be 32 bytes length"))
+}
+
+/// Convert a JS byte array into a RedPallas binding signature, rejecting the
+/// wrong length instead of panicking on the `TryInto`.
+pub fn js_bytes_to_binding_signature(
+    js_binding_signature: Uint8Array,
+) -> Result<[u8; 64], napi::Error> {
+    js_binding_signature.to_vec().try_into().map_err(|_| {
+        napi::Error::new(
+            Status::InvalidArg,
+            "bindings_signature must be 64 bytes length",
+        )
+    })
 }

--- a/src/verify/state_transition/entities.rs
+++ b/src/verify/state_transition/entities.rs
@@ -4,7 +4,7 @@ use dpp::{
         reduced_asset_lock_value::{AssetLockValue, AssetLockValueGettersV0},
     },
     block::{block_info::BlockInfo, epoch::Epoch},
-    state_transition::proof_result::StateTransitionProofResult,
+    state_transition::proof_result::StateTransitionProofOutcome,
     tokens::{
         info::{IdentityTokenInfo, v0::IdentityTokenInfoV0Accessors},
         status::{TokenStatus, v0::TokenStatusV0Accessors},
@@ -127,7 +127,7 @@ impl BlockInfoNAPI {
 #[napi(js_name = "VerifiedStateTransitionResultNAPI")]
 pub struct VerifiedStateTransitionResultNAPI {
     pub root_hash: Uint8Array,
-    pub(crate) result: StateTransitionProofResult,
+    pub(crate) result: StateTransitionProofOutcome,
 }
 
 #[napi]
@@ -166,7 +166,15 @@ impl VerifiedStateTransitionResultNAPI {
         >,
         napi::Error,
     > {
-        state_transition_proof_result_to_js(&self.result)
+        state_transition_proof_result_to_js(self.result.result())
+    }
+
+    /// Whether the proof binds the execution of this specific state transition.
+    /// When false the result is a height-pinned snapshot of the affected state,
+    /// not evidence that the transition executed.
+    #[napi(getter, js_name = "isExecutionProved")]
+    pub fn is_execution_proved(&self) -> bool {
+        self.result.is_execution_proved()
     }
 }
 

--- a/tests/unit/ShieldedTransitions.spec.ts
+++ b/tests/unit/ShieldedTransitions.spec.ts
@@ -18,6 +18,7 @@ import {
   Purpose,
   SecurityLevel,
   KeyType,
+  PlatformVersionWASM,
   StateTransitionWASM
 } from 'pshenmic-dpp'
 
@@ -190,6 +191,27 @@ describe('ShieldedTransferTransition', function () {
       expect(restored.actions.length).toEqual(1)
     })
   })
+
+  describe('computeMinimumFee', function () {
+    test('should return a positive fee', function () {
+      const fee = ShieldedTransferTransitionWASM.computeMinimumFee(2)
+
+      expect(typeof fee).toEqual('bigint')
+      expect(fee).toBeGreaterThan(BigInt(0))
+    })
+
+    test('should grow with the action count', function () {
+      const oneAction = ShieldedTransferTransitionWASM.computeMinimumFee(1)
+      const twoActions = ShieldedTransferTransitionWASM.computeMinimumFee(2)
+
+      expect(twoActions).toBeGreaterThan(oneAction)
+    })
+
+    test('should default to the latest platform version', function () {
+      expect(ShieldedTransferTransitionWASM.computeMinimumFee(2))
+        .toEqual(ShieldedTransferTransitionWASM.computeMinimumFee(2, PlatformVersionWASM.PLATFORM_V12))
+    })
+  })
 })
 
 describe('ShieldTransition', function () {
@@ -291,6 +313,27 @@ describe('ShieldTransition', function () {
       expect(restored.actions.length).toEqual(1)
     })
   })
+
+  describe('computeMinimumFee', function () {
+    test('should return a positive fee', function () {
+      const fee = ShieldTransitionWASM.computeMinimumFee(2)
+
+      expect(typeof fee).toEqual('bigint')
+      expect(fee).toBeGreaterThan(BigInt(0))
+    })
+
+    test('should grow with the action count', function () {
+      const oneAction = ShieldTransitionWASM.computeMinimumFee(1)
+      const twoActions = ShieldTransitionWASM.computeMinimumFee(2)
+
+      expect(twoActions).toBeGreaterThan(oneAction)
+    })
+
+    test('should default to the latest platform version', function () {
+      expect(ShieldTransitionWASM.computeMinimumFee(2))
+        .toEqual(ShieldTransitionWASM.computeMinimumFee(2, PlatformVersionWASM.PLATFORM_V12))
+    })
+  })
 })
 
 describe('UnshieldTransition', function () {
@@ -379,6 +422,27 @@ describe('UnshieldTransition', function () {
       expect(restored.anchor).toEqual(anchor)
       expect(restored.proof).toEqual(proof)
       expect(restored.bindingsSignature).toEqual(bindingsSignature)
+    })
+  })
+
+  describe('computeMinimumFee', function () {
+    test('should return a positive fee', function () {
+      const fee = UnshieldTransitionWASM.computeMinimumFee(2)
+
+      expect(typeof fee).toEqual('bigint')
+      expect(fee).toBeGreaterThan(BigInt(0))
+    })
+
+    test('should grow with the action count', function () {
+      const oneAction = UnshieldTransitionWASM.computeMinimumFee(1)
+      const twoActions = UnshieldTransitionWASM.computeMinimumFee(2)
+
+      expect(twoActions).toBeGreaterThan(oneAction)
+    })
+
+    test('should default to the latest platform version', function () {
+      expect(UnshieldTransitionWASM.computeMinimumFee(2))
+        .toEqual(UnshieldTransitionWASM.computeMinimumFee(2, PlatformVersionWASM.PLATFORM_V12))
     })
   })
 })
@@ -491,6 +555,27 @@ describe('ShieldFromAssetLockTransition', function () {
       expect(restored.actions.length).toEqual(1)
     })
   })
+
+  describe('computeMinimumFee', function () {
+    test('should return a positive fee', function () {
+      const fee = ShieldFromAssetLockTransitionWASM.computeMinimumFee(2)
+
+      expect(typeof fee).toEqual('bigint')
+      expect(fee).toBeGreaterThan(BigInt(0))
+    })
+
+    test('should grow with the action count', function () {
+      const oneAction = ShieldFromAssetLockTransitionWASM.computeMinimumFee(1)
+      const twoActions = ShieldFromAssetLockTransitionWASM.computeMinimumFee(2)
+
+      expect(twoActions).toBeGreaterThan(oneAction)
+    })
+
+    test('should default to the latest platform version', function () {
+      expect(ShieldFromAssetLockTransitionWASM.computeMinimumFee(2))
+        .toEqual(ShieldFromAssetLockTransitionWASM.computeMinimumFee(2, PlatformVersionWASM.PLATFORM_V12))
+    })
+  })
 })
 
 describe('ShieldedWithdrawalTransition', function () {
@@ -588,6 +673,27 @@ describe('ShieldedWithdrawalTransition', function () {
       expect(restored.bindingsSignature).toEqual(bindingsSignature)
       expect(restored.coreFeePerByte).toEqual(coreFeePerByte)
       expect(restored.pooling).toEqual('Never')
+    })
+  })
+
+  describe('computeMinimumFee', function () {
+    test('should return a positive fee', function () {
+      const fee = ShieldedWithdrawalTransitionWASM.computeMinimumFee(2)
+
+      expect(typeof fee).toEqual('bigint')
+      expect(fee).toBeGreaterThan(BigInt(0))
+    })
+
+    test('should grow with the action count', function () {
+      const oneAction = ShieldedWithdrawalTransitionWASM.computeMinimumFee(1)
+      const twoActions = ShieldedWithdrawalTransitionWASM.computeMinimumFee(2)
+
+      expect(twoActions).toBeGreaterThan(oneAction)
+    })
+
+    test('should default to the latest platform version', function () {
+      expect(ShieldedWithdrawalTransitionWASM.computeMinimumFee(2))
+        .toEqual(ShieldedWithdrawalTransitionWASM.computeMinimumFee(2, PlatformVersionWASM.PLATFORM_V12))
     })
   })
 })
@@ -705,5 +811,67 @@ describe('IdentityCreateFromShieldedPoolTransition', function () {
       expect(restored.sendToAddressOnCreationFailure.bytes()).toEqual(sendToAddressOnCreationFailure.bytes())
       expect(restored.identityId.bytes()).toEqual(identityId.bytes())
     })
+  })
+
+  describe('computeMinimumFee', function () {
+    test('should return a positive fee', function () {
+      const fee = IdentityCreateFromShieldedPoolTransitionWASM.computeMinimumFee(2, 3)
+
+      expect(typeof fee).toEqual('bigint')
+      expect(fee).toBeGreaterThan(BigInt(0))
+    })
+
+    test('should grow with the action count', function () {
+      const oneAction = IdentityCreateFromShieldedPoolTransitionWASM.computeMinimumFee(1, 3)
+      const twoActions = IdentityCreateFromShieldedPoolTransitionWASM.computeMinimumFee(2, 3)
+
+      expect(twoActions).toBeGreaterThan(oneAction)
+    })
+
+    test('should grow with the key count', function () {
+      const oneKey = IdentityCreateFromShieldedPoolTransitionWASM.computeMinimumFee(2, 1)
+      const threeKeys = IdentityCreateFromShieldedPoolTransitionWASM.computeMinimumFee(2, 3)
+
+      expect(threeKeys).toBeGreaterThan(oneKey)
+    })
+
+    test('should default to the latest platform version', function () {
+      expect(IdentityCreateFromShieldedPoolTransitionWASM.computeMinimumFee(2, 3))
+        .toEqual(IdentityCreateFromShieldedPoolTransitionWASM.computeMinimumFee(2, 3, PlatformVersionWASM.PLATFORM_V12))
+    })
+  })
+})
+
+describe('computeMinimumFee across shielded transitions', function () {
+  const numActions = 2
+
+  test('Shield should be the compute-only fee, without the per-action storage term', function () {
+    expect(ShieldTransitionWASM.computeMinimumFee(numActions))
+      .toBeLessThan(ShieldedTransferTransitionWASM.computeMinimumFee(numActions))
+  })
+
+  test('Shield and ShieldedTransfer should agree with no actions', function () {
+    expect(ShieldTransitionWASM.computeMinimumFee(0))
+      .toEqual(ShieldedTransferTransitionWASM.computeMinimumFee(0))
+  })
+
+  test('ShieldFromAssetLock should match ShieldedTransfer', function () {
+    expect(ShieldFromAssetLockTransitionWASM.computeMinimumFee(numActions))
+      .toEqual(ShieldedTransferTransitionWASM.computeMinimumFee(numActions))
+  })
+
+  test('Unshield should add the output address write on top of ShieldedTransfer', function () {
+    expect(UnshieldTransitionWASM.computeMinimumFee(numActions))
+      .toBeGreaterThan(ShieldedTransferTransitionWASM.computeMinimumFee(numActions))
+  })
+
+  test('ShieldedWithdrawal should add the withdrawal document write on top of Unshield', function () {
+    expect(ShieldedWithdrawalTransitionWASM.computeMinimumFee(numActions))
+      .toBeGreaterThan(UnshieldTransitionWASM.computeMinimumFee(numActions))
+  })
+
+  test('IdentityCreateFromShieldedPool should add the identity create floor on top of ShieldedTransfer', function () {
+    expect(IdentityCreateFromShieldedPoolTransitionWASM.computeMinimumFee(numActions, 1))
+      .toBeGreaterThan(ShieldedTransferTransitionWASM.computeMinimumFee(numActions))
   })
 })


### PR DESCRIPTION
# Issue
Bindings must be migrated to new version dpp v4.1.0.
Also previous version of dpp doesn't contains accessors for shielded transitions

# Things done
- Bumped version of `dpp`, `drive` and `grovedb-commitment-tree `
- Re-Implemented getters and setters for shielded transitions, now via struct accessors
- Implemented `computeMinimumFee` method for shielded transitions
- Added `nullifier` getter for `RecoveredNoteWASM` on ts side
- Add platform version 13