### PR TITLE
Add fee calculation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,16 +59,24 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-wasip1-threads, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, aarch64-linux-android, x86_64-linux-android, aarch64-apple-ios-sim, aarch64-apple-darwin, x86_64-apple-darwin
+          targets: wasm32-wasip1-threads, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, aarch64-linux-android, x86_64-linux-android, aarch64-apple-ios-sim, aarch64-apple-darwin, x86_64-apple-darwin, x86_64-pc-windows-msvc, aarch64-pc-windows-msvc
           components: rustfmt, rust-src
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2
 
+      # The Microsoft CRT/SDK headers cargo-xwin downloads for the windows-msvc
+      # targets are ~1GB and are not covered by rust-cache.
+      - name: Cache xwin CRT/SDK
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/cargo-xwin
+          key: ${{ runner.os }}-cargo-xwin
+
       - name: Install pre-built Rust tools
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-zigbuild, wasm-bindgen-cli@0.2.105, wasm-opt
+          tool: cargo-zigbuild, cargo-xwin, wasm-bindgen-cli@0.2.105, wasm-opt
 
       - name: Install LLVM for WebAssembly (macOS)
         run: |
@@ -83,8 +91,10 @@ jobs:
         run: yarn build:full
         env:
           RUSTFLAGS: '-C target-feature=-crt-static'
-          NATIVE_BUILD_TARGET: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,aarch64-apple-darwin,x86_64-apple-darwin
+          NATIVE_BUILD_TARGET: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,aarch64-apple-darwin,x86_64-apple-darwin,x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
           WASM_TOOLCHAIN: nightly-2026-06-17
+          # Accepts Microsoft's license for the CRT/SDK headers cargo-xwin downloads.
+          XWIN_ACCEPT_LICENSE: '1'
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -106,6 +116,8 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,16 +57,24 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-wasip1-threads, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, aarch64-linux-android, x86_64-linux-android, aarch64-apple-ios-sim, aarch64-apple-darwin, x86_64-apple-darwin
+          targets: wasm32-wasip1-threads, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, aarch64-linux-android, x86_64-linux-android, aarch64-apple-ios-sim, aarch64-apple-darwin, x86_64-apple-darwin, x86_64-pc-windows-msvc, aarch64-pc-windows-msvc
           components: rustfmt, rust-src
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2
 
+      # The Microsoft CRT/SDK headers cargo-xwin downloads for the windows-msvc
+      # targets are ~1GB and are not covered by rust-cache.
+      - name: Cache xwin CRT/SDK
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/cargo-xwin
+          key: ${{ runner.os }}-cargo-xwin
+
       - name: Install pre-built Rust tools
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-zigbuild, wasm-bindgen-cli@0.2.105, wasm-opt
+          tool: cargo-zigbuild, cargo-xwin, wasm-bindgen-cli@0.2.105, wasm-opt
 
       - name: Install LLVM for WebAssembly (macOS)
         run: |
@@ -81,8 +89,10 @@ jobs:
         run: yarn build:full
         env:
           RUSTFLAGS: '-C target-feature=-crt-static'
-          NATIVE_BUILD_TARGET: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,aarch64-apple-darwin,x86_64-apple-darwin
+          NATIVE_BUILD_TARGET: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,aarch64-apple-darwin,x86_64-apple-darwin,x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
           WASM_TOOLCHAIN: nightly-2026-06-17
+          # Accepts Microsoft's license for the CRT/SDK headers cargo-xwin downloads.
+          XWIN_ACCEPT_LICENSE: '1'
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -104,6 +114,8 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
 
     steps:
       - name: Checkout repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "pshenmic-dpp"
-version = "2.0.0-dev.26"
+version = "2.0.0-dev.27"
 dependencies = [
  "async-trait",
  "dpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pshenmic-dpp"
 authors = ["owl352 <kokosinca123@gmail.com>"]
-version = "2.0.0-dev.26"
+version = "2.0.0-dev.27"
 edition = "2024"
 
 [lib]

--- a/build.cjs
+++ b/build.cjs
@@ -35,8 +35,8 @@ const nativeTargets = specificTarget
     "aarch64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
     "aarch64-unknown-linux-musl",
-    // "x86_64-pc-windows-msvc",
-    // "aarch64-pc-windows-msvc"
+    "x86_64-pc-windows-msvc",
+    "aarch64-pc-windows-msvc",
   ];
 
 const emnapi = path.join(
@@ -83,7 +83,12 @@ async function main() {
   console.log("--- Building Native Binaries ---");
 
   const darwinTargets = nativeTargets.filter(t => t.includes("apple-darwin"));
-  const zigbuildTargets = nativeTargets.filter(t => !t.includes("apple-darwin"));
+  // zig cannot emit the MSVC ABI, so windows goes through cargo-xwin (clang-cl
+  // + lld-link against the Microsoft CRT/SDK headers xwin downloads).
+  const windowsTargets = nativeTargets.filter(t => t.includes("windows"));
+  const zigbuildTargets = nativeTargets.filter(
+    t => !t.includes("apple-darwin") && !t.includes("windows")
+  );
 
   if (darwinTargets.length > 0) {
     const targetFlags = darwinTargets.map(t => `--target ${t}`).join(" ");
@@ -105,19 +110,36 @@ async function main() {
     );
   }
 
+  // One invocation per windows target: cargo-xwin injects the SDK/CRT lib
+  // paths via RUSTFLAGS, and with several `--target` flags only the last
+  // target's paths survive, so the others fail to link ("machine type x64
+  // conflicts with arm64"). Requires XWIN_ACCEPT_LICENSE=1 in the environment
+  // (accepts Microsoft's license for the CRT/SDK headers xwin downloads).
+  for (const target of windowsTargets) {
+    console.log(`Building windows target with xwin: ${target}...`);
+
+    await execTask(
+      `cargo xwin build --target ${target} ${isRelease ? "--release" : ""}`,
+      { env: { ...process.env }, maxBuffer: 1024 * 1024 * 50 }
+    );
+  }
+
   nativeTargets.forEach((target) => {
     let extension;
+    // MSVC emits `pshenmic_dpp.dll`; the unix toolchains prefix with `lib`.
+    let prefix = "lib";
 
     if (target.includes("apple-darwin")) {
       extension = "dylib";
     } else if (target.includes("windows")) {
       extension = "dll";
+      prefix = "";
     } else {
       extension = "so";
     }
 
     const nativeBinPath = path.join(
-      __dirname, "target", target, buildProfile, `lib${binName}.${extension}`
+      __dirname, "target", target, buildProfile, `${prefix}${binName}.${extension}`
     );
 
     const nativeOutputDir = path.join(binariesOutputDir, "native", target);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pshenmic-dpp",
-  "version": "2.0.0-dev.26",
+  "version": "2.0.0-dev.27",
   "main": "dist/src/wasm.js",
   "types": "dist/src/wasm.d.ts",
   "react-native": "./dist/src/react-native.js",

--- a/pkg/src/dpp/structs/AddressTransitions/AddressCreditWithdrawalTransition.ts
+++ b/pkg/src/dpp/structs/AddressTransitions/AddressCreditWithdrawalTransition.ts
@@ -1,4 +1,4 @@
-import type { AddressCreditWithdrawalTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { AddressCreditWithdrawalTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { InputAddressWASM } from './entities/InputAddress.js'
 import { AddressFundsFeeStrategyStepWASM } from './entities/AddressFundsFeeStrategyStep.js'
 import { PoolingLike } from '../../types.js'
@@ -101,6 +101,18 @@ export class AddressCreditWithdrawalTransitionWASM {
 
   set inputWitness (value: AddressWitnessWASM[]) {
     this._rawAddressCreditWithdrawalTransition.inputWitness = value.map(witness => witness._rawWitness)
+  }
+
+  static estimateMinFee (
+    inputCount: number,
+    hasChangeOutput: boolean,
+    platformVersion?: PlatformVersionNAPI
+  ): bigint {
+    return BigInt(dppProvider.dpp.AddressCreditWithdrawalTransitionNAPI.estimateMinFee(inputCount, hasChangeOutput, platformVersion))
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawAddressCreditWithdrawalTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/AddressTransitions/AddressFundingFromAssetLockTransition.ts
+++ b/pkg/src/dpp/structs/AddressTransitions/AddressFundingFromAssetLockTransition.ts
@@ -1,4 +1,4 @@
-import type { AddressFundingFromAssetLockTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { AddressFundingFromAssetLockTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { AssetLockProofWASM } from '../AssetLockProof/AssetLockProof.js'
 import { InputAddressWASM } from './entities/InputAddress.js'
 import { AddressFundsFeeStrategyStepWASM } from './entities/AddressFundsFeeStrategyStep.js'
@@ -83,6 +83,10 @@ export class AddressFundingFromAssetLockTransitionWASM {
 
   set signature (value: Uint8Array) {
     this._rawAddressFundingFromAssetLockTransition.signature = value
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawAddressFundingFromAssetLockTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/AddressTransitions/AddressFundsTransferTransition.ts
+++ b/pkg/src/dpp/structs/AddressTransitions/AddressFundsTransferTransition.ts
@@ -1,4 +1,4 @@
-import type { AddressFundsTransferTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { AddressFundsTransferTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { InputAddressWASM } from './entities/InputAddress.js'
 import { AddressFundsFeeStrategyStepWASM } from './entities/AddressFundsFeeStrategyStep.js'
 import { AddressWitnessWASM } from '../PlatformAddress/AddressWitness.js'
@@ -64,6 +64,18 @@ export class AddressFundsTransferTransitionWASM {
 
   set inputWitness (witness: AddressWitnessWASM[]) {
     this._rawAddressFundsTransferTransition.inputWitness = witness.map(w => w._rawWitness)
+  }
+
+  static estimateMinFee (
+    inputCount: number,
+    outputCount: number,
+    platformVersion?: PlatformVersionNAPI
+  ): bigint {
+    return BigInt(dppProvider.dpp.AddressFundsTransferTransitionNAPI.estimateMinFee(inputCount, outputCount, platformVersion))
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawAddressFundsTransferTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/AddressTransitions/IdentityCreateFromAddressesTransition.ts
+++ b/pkg/src/dpp/structs/AddressTransitions/IdentityCreateFromAddressesTransition.ts
@@ -1,4 +1,4 @@
-import type { IdentityCreateFromAddressesTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { IdentityCreateFromAddressesTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { IdentityPublicKeyInCreationWASM } from '../IdentityPublicKeyInCreation.js'
 import { InputAddressWASM } from './entities/InputAddress.js'
 import { AddressFundsFeeStrategyStepWASM } from './entities/AddressFundsFeeStrategyStep.js'
@@ -79,6 +79,10 @@ export class IdentityCreateFromAddressesTransitionWASM {
 
   set inputWitness (value: AddressWitnessWASM[]) {
     this._rawIdentityCreateFromAddressesTransition.inputWitness = value.map(w => w._rawWitness)
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawIdentityCreateFromAddressesTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/AddressTransitions/IdentityCreditTransferToAddressesTransition.ts
+++ b/pkg/src/dpp/structs/AddressTransitions/IdentityCreditTransferToAddressesTransition.ts
@@ -1,4 +1,4 @@
-import type { IdentityCreditTransferToAddressesTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { IdentityCreditTransferToAddressesTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { IdentifierLike } from '../../types.js'
 import { OutputAddressWASM } from './entities/OutputAddress.js'
 import { dppProvider } from '../../provider.js'
@@ -65,6 +65,10 @@ export class IdentityCreditTransferToAddressesTransitionWASM {
 
   set signature (sig: Uint8Array) {
     this._rawIdentityCreditTransferToAddressesTransition.signature = sig
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawIdentityCreditTransferToAddressesTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/AddressTransitions/IdentityTopUpFromAddressesTransition.ts
+++ b/pkg/src/dpp/structs/AddressTransitions/IdentityTopUpFromAddressesTransition.ts
@@ -1,4 +1,4 @@
-import type { IdentityTopUpFromAddressesTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { IdentityTopUpFromAddressesTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { dppProvider } from '../../provider.js'
 import { IdentifierLike } from '../../types.js'
 import { InputAddressWASM } from './entities/InputAddress.js'
@@ -72,6 +72,10 @@ export class IdentityTopUpFromAddressesTransitionWASM {
 
   set inputWitness (addressWitness: AddressWitnessWASM[]) {
     this._rawIdentityTopUpFromAddressesTransition.inputWitness = addressWitness.map(w => w._rawWitness)
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawIdentityTopUpFromAddressesTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/Batch/BatchTransition.ts
+++ b/pkg/src/dpp/structs/Batch/BatchTransition.ts
@@ -1,4 +1,4 @@
-import type { BatchTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { BatchTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { IdentifierLike } from '../../types.js'
 import { dppProvider } from '../../provider.js'
 import { BatchedTransitionWASM } from './BatchedTransition.js'
@@ -109,6 +109,10 @@ export class BatchTransitionWASM {
 
   setIdentityContractNonce (nonce: bigint): void {
     this._rawBatchTransition.setIdentityContractNonce(nonce.toString())
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawBatchTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/DataContractTransitions/DataContractCreateTransition.ts
+++ b/pkg/src/dpp/structs/DataContractTransitions/DataContractCreateTransition.ts
@@ -1,4 +1,4 @@
-import type { DataContractCreateTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { DataContractCreateTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { DataContractWASM } from '../DataContract.js'
 import { PlatformVersionLike } from '../../types.js'
 import { dppProvider } from '../../provider.js'
@@ -41,6 +41,10 @@ export class DataContractCreateTransitionWASM {
     return DataContractWASM.createFromRawInstance(
       this._rawDataContractCreateTransition.getDataContract(valueToDynamicValue(platformVersion), fullValidation)
     )
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawDataContractCreateTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/DataContractTransitions/DataContractUpdateTransition.ts
+++ b/pkg/src/dpp/structs/DataContractTransitions/DataContractUpdateTransition.ts
@@ -1,4 +1,4 @@
-import type { DataContractUpdateTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { DataContractUpdateTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { DataContractWASM } from '../DataContract.js'
 import { PlatformVersionLike } from '../../types.js'
 import { dppProvider } from '../../provider.js'
@@ -41,6 +41,10 @@ export class DataContractUpdateTransitionWASM {
     return DataContractWASM.createFromRawInstance(
       this._rawDataContractUpdateTransition.getDataContract(fullValidation, valueToDynamicValue(platformVersion))
     )
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawDataContractUpdateTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/IdentityTransitions/IdentityCreateTransition.ts
+++ b/pkg/src/dpp/structs/IdentityTransitions/IdentityCreateTransition.ts
@@ -1,4 +1,4 @@
-import type { IdentityCreateTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { IdentityCreateTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { IdentityPublicKeyInCreationWASM } from '../IdentityPublicKeyInCreation.js'
 import { AssetLockProofWASM } from '../AssetLockProof/AssetLockProof.js'
 import { dppProvider } from '../../provider.js'
@@ -58,6 +58,10 @@ export class IdentityCreateTransitionWASM {
 
   getIdentifier (): IdentifierWASM {
     return IdentifierWASM.createFromRawInstance(this._rawIdentityCreateTransition.getIdentifier())
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawIdentityCreateTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/IdentityTransitions/IdentityCreditTransfer.ts
+++ b/pkg/src/dpp/structs/IdentityTransitions/IdentityCreditTransfer.ts
@@ -1,4 +1,4 @@
-import type { IdentityCreditTransferNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { IdentityCreditTransferNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { IdentifierLike } from '../../types.js'
 import { dppProvider } from '../../provider.js'
 import { prepareIdentifierValue } from '../../utils.js'
@@ -77,6 +77,10 @@ export class IdentityCreditTransferWASM {
 
   getSignableBytes (): Uint8Array {
     return this._rawIdentityCreditTransfer.getSignableBytes()
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawIdentityCreditTransfer.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/IdentityTransitions/IdentityCreditWithdrawalTransition.ts
+++ b/pkg/src/dpp/structs/IdentityTransitions/IdentityCreditWithdrawalTransition.ts
@@ -1,4 +1,4 @@
-import type { IdentityCreditWithdrawalTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { IdentityCreditWithdrawalTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { dppProvider } from '../../provider.js'
 import { IdentifierLike, PoolingLike } from '../../types.js'
 import { CoreScriptWASM } from '../CoreScript.js'
@@ -125,6 +125,10 @@ export class IdentityCreditWithdrawalTransitionWASM {
     if (lock != null) {
       return AssetLockProofWASM.createFromRawInstance(lock)
     }
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawIdentityCreditWithdrawalTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/IdentityTransitions/IdentityTopUpTransition.ts
+++ b/pkg/src/dpp/structs/IdentityTransitions/IdentityTopUpTransition.ts
@@ -1,4 +1,4 @@
-import type { IdentityTopUpTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { IdentityTopUpTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { AssetLockProofWASM } from '../AssetLockProof/AssetLockProof.js'
 import { IdentifierLike } from '../../types.js'
 import { dppProvider } from '../../provider.js'
@@ -61,6 +61,10 @@ export class IdentityTopUpTransitionWASM {
   getOptionalAssetLockProof (): AssetLockProofWASM | undefined {
     const lock = this._rawIdentityTopUpTransition.getOptionalAssetLockProof()
     return (lock != null) ? AssetLockProofWASM.createFromRawInstance(lock) : undefined
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawIdentityTopUpTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/IdentityTransitions/IdentityUpdateTransition.ts
+++ b/pkg/src/dpp/structs/IdentityTransitions/IdentityUpdateTransition.ts
@@ -1,4 +1,4 @@
-import type { IdentityUpdateTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { IdentityUpdateTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { IdentifierLike } from '../../types.js'
 import { IdentityPublicKeyInCreationWASM } from '../IdentityPublicKeyInCreation.js'
 import { dppProvider } from '../../provider.js'
@@ -112,6 +112,10 @@ export class IdentityUpdateTransitionWASM {
     } else {
       return undefined
     }
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawIdentityUpdateTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/MasternodeVote/MasternodeVoteTransition.ts
+++ b/pkg/src/dpp/structs/MasternodeVote/MasternodeVoteTransition.ts
@@ -1,4 +1,4 @@
-import type { MasternodeVoteTransitionNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { MasternodeVoteTransitionNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { IdentifierLike } from '../../types.js'
 import { VoteWASM } from './Vote.js'
 import { dppProvider } from '../../provider.js'
@@ -84,6 +84,10 @@ export class MasternodeVoteTransitionWASM {
 
   getSignableBytes (): Uint8Array {
     return this._rawMasternodeVoteTransition.getSignableBytes()
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawMasternodeVoteTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/pkg/src/dpp/structs/PlatformAddress/PlatformAddress.ts
+++ b/pkg/src/dpp/structs/PlatformAddress/PlatformAddress.ts
@@ -1,4 +1,4 @@
-import type { PlatformAddressNAPI } from '../../../../binaries/bindingsTypes.js'
+import type { PlatformAddressNAPI, PlatformVersionNAPI } from '../../../../binaries/bindingsTypes.js'
 import { dppProvider } from '../../provider.js'
 import { NetworkLike, PlatformAddressLike } from '../../types.js'
 import { preparePlatformAddressValue, valueToDynamicValue } from '../../utils.js'
@@ -33,6 +33,20 @@ export class PlatformAddressWASM {
 
   hash (): Uint8Array {
     return this._rawPlatformAddress.hash()
+  }
+
+  /**
+   * Storage fee charged for creating balance entries for addresses that are not in state yet.
+   *
+   * A minimum fee prices every output as a fresh address, but the fee actually charged is
+   * metered: paying an address that already exists adds no bytes, while each address created
+   * costs this much storage on top of processing.
+   */
+  static estimateStorageFeeForNewAddresses (
+    addressCount: number,
+    platformVersion?: PlatformVersionNAPI
+  ): bigint {
+    return BigInt(dppProvider.dpp.PlatformAddressNAPI.estimateStorageFeeForNewAddresses(addressCount, platformVersion))
   }
 
   static fromBech32m (bech32m: string): PlatformAddressWASM {

--- a/pkg/src/dpp/structs/StateTransition.ts
+++ b/pkg/src/dpp/structs/StateTransition.ts
@@ -1,4 +1,4 @@
-import type { StateTransitionNAPI } from '../../../binaries/bindingsTypes.js'
+import type { StateTransitionNAPI, PlatformVersionNAPI } from '../../../binaries/bindingsTypes.js'
 import { dppProvider } from '../provider.js'
 import { PrivateKeyWASM } from './PrivateKey.js'
 import { IdentityPublicKeyWASM } from './IdentityPublicKey.js'
@@ -114,6 +114,10 @@ export class StateTransitionWASM {
 
   getSignableBytes (): Uint8Array {
     return this._rawStateTransition.getSignableBytes()
+  }
+
+  calculateMinRequiredFee (platformVersion?: PlatformVersionNAPI): bigint {
+    return BigInt(this._rawStateTransition.calculateMinRequiredFee(platformVersion))
   }
 
   bytes (): Uint8Array {

--- a/src/address_transitions/address_credit_withdrawal_transition.rs
+++ b/src/address_transitions/address_credit_withdrawal_transition.rs
@@ -6,9 +6,10 @@ use dpp::state_transition::address_credit_withdrawal_transition::AddressCreditWi
 use dpp::state_transition::address_credit_withdrawal_transition::accessors::AddressCreditWithdrawalTransitionAccessorsV0;
 use dpp::state_transition::address_credit_withdrawal_transition::v0::AddressCreditWithdrawalTransitionV0;
 use dpp::state_transition::{
-    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionHasUserFeeIncrease,
-    StateTransitionWitnessSigned,
+    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionEstimatedFeeValidation,
+    StateTransitionHasUserFeeIncrease, StateTransitionWitnessSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
@@ -17,6 +18,7 @@ use crate::address_transitions::entities::input_address::InputAddressNAPI;
 use crate::address_transitions::entities::output_address::OutputAddressNAPI;
 use crate::core_script::CoreScriptNAPI;
 use crate::dynamic_value::{BigIntString, DynamicValue, TryToU64};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::enums::pooling::PoolingNAPI;
 use crate::platform_address::address_witness::AddressWitnessNAPI;
 use crate::state_transition::StateTransitionNAPI;
@@ -210,6 +212,34 @@ impl AddressCreditWithdrawalTransitionNAPI {
             .collect();
 
         self.0.set_witnesses(input_witnesses);
+    }
+
+    #[napi(js_name = "estimateMinFee")]
+    pub fn estimate_min_fee(
+        js_input_count: u32,
+        js_has_change_output: bool,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> BigIntString {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        BigIntString::from_u64(AddressCreditWithdrawalTransition::estimate_min_fee(
+            js_input_count as usize,
+            js_has_change_output,
+            &platform_version,
+        ))
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/address_transitions/address_funding_from_asset_lock_transition.rs
+++ b/src/address_transitions/address_funding_from_asset_lock_transition.rs
@@ -5,9 +5,10 @@ use dpp::state_transition::address_funding_from_asset_lock_transition::AddressFu
 use dpp::state_transition::address_funding_from_asset_lock_transition::accessors::AddressFundingFromAssetLockTransitionAccessorsV0;
 use dpp::state_transition::address_funding_from_asset_lock_transition::v0::AddressFundingFromAssetLockTransitionV0;
 use dpp::state_transition::{
-    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionHasUserFeeIncrease,
-    StateTransitionSingleSigned, StateTransitionWitnessSigned,
+    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionEstimatedFeeValidation,
+    StateTransitionHasUserFeeIncrease, StateTransitionSingleSigned, StateTransitionWitnessSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
@@ -16,6 +17,7 @@ use crate::address_transitions::entities::input_address::InputAddressNAPI;
 use crate::address_transitions::entities::output_address::OutputAddressNullableCreditsNAPI;
 use crate::asset_lock_proof::AssetLockProofNAPI;
 use crate::dynamic_value::{BigIntString, TryToU64};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::platform_address::address_witness::AddressWitnessNAPI;
 use crate::state_transition::StateTransitionNAPI;
 use crate::utils::{WithJsError, js_inputs_to_inputs, js_outputs_to_outputs_nullable};
@@ -188,6 +190,19 @@ impl AddressFundingFromAssetLockTransitionNAPI {
             .collect();
 
         self.0.set_witnesses(input_witnesses);
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/address_transitions/address_funds_transfer.rs
+++ b/src/address_transitions/address_funds_transfer.rs
@@ -7,8 +7,10 @@ use dpp::state_transition::address_funds_transfer_transition::AddressFundsTransf
 use dpp::state_transition::address_funds_transfer_transition::accessors::AddressFundsTransferTransitionAccessorsV0;
 use dpp::state_transition::address_funds_transfer_transition::v0::AddressFundsTransferTransitionV0;
 use dpp::state_transition::{
-    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionWitnessSigned,
+    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionEstimatedFeeValidation,
+    StateTransitionWitnessSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 use std::collections::BTreeMap;
@@ -17,6 +19,7 @@ use crate::address_transitions::entities::address_funds_fee_step::AddressFundsFe
 use crate::address_transitions::entities::input_address::InputAddressNAPI;
 use crate::address_transitions::entities::output_address::OutputAddressNAPI;
 use crate::dynamic_value::{BigIntString, TryToU64};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::platform_address::address_witness::AddressWitnessNAPI;
 use crate::state_transition::StateTransitionNAPI;
 use crate::utils::{WithJsError, js_inputs_to_inputs, js_outputs_to_outputs};
@@ -158,6 +161,34 @@ impl AddressFundsTransferTransitionNAPI {
             .collect();
 
         self.0.set_witnesses(input_witnesses);
+    }
+
+    #[napi(js_name = "estimateMinFee")]
+    pub fn estimate_min_fee(
+        js_input_count: u32,
+        js_output_count: u32,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> BigIntString {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        BigIntString::from_u64(AddressFundsTransferTransition::estimate_min_fee(
+            js_input_count as usize,
+            js_output_count as usize,
+            &platform_version,
+        ))
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/address_transitions/create_from_address_transition.rs
+++ b/src/address_transitions/create_from_address_transition.rs
@@ -8,8 +8,10 @@ use dpp::state_transition::identity_create_from_addresses_transition::accessors:
 use dpp::state_transition::identity_create_from_addresses_transition::v0::IdentityCreateFromAddressesTransitionV0;
 use dpp::state_transition::public_key_in_creation::IdentityPublicKeyInCreation;
 use dpp::state_transition::{
-    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionWitnessSigned,
+    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionEstimatedFeeValidation,
+    StateTransitionWitnessSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
@@ -17,6 +19,7 @@ use crate::address_transitions::entities::address_funds_fee_step::AddressFundsFe
 use crate::address_transitions::entities::input_address::InputAddressNAPI;
 use crate::address_transitions::entities::output_address::OutputAddressNAPI;
 use crate::dynamic_value::{BigIntString, TryToU64};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::identity_public_key_in_creation::IdentityPublicKeyInCreationNAPI;
 use crate::platform_address::address_witness::AddressWitnessNAPI;
 use crate::state_transition::StateTransitionNAPI;
@@ -198,6 +201,19 @@ impl IdentityCreateFromAddressesTransitionNAPI {
             .collect();
 
         self.0.set_witnesses(input_witnesses);
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/address_transitions/identity_credit_transfer_to_addresses_transition.rs
+++ b/src/address_transitions/identity_credit_transfer_to_addresses_transition.rs
@@ -5,13 +5,16 @@ use dpp::state_transition::identity_credit_transfer_to_addresses_transition::Ide
 use dpp::state_transition::identity_credit_transfer_to_addresses_transition::accessors::IdentityCreditTransferToAddressesTransitionAccessorsV0;
 use dpp::state_transition::identity_credit_transfer_to_addresses_transition::v0::IdentityCreditTransferToAddressesTransitionV0;
 use dpp::state_transition::{
-    StateTransition, StateTransitionIdentitySigned, StateTransitionSingleSigned,
+    StateTransition, StateTransitionEstimatedFeeValidation, StateTransitionIdentitySigned,
+    StateTransitionSingleSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::address_transitions::entities::output_address::OutputAddressNAPI;
 use crate::dynamic_value::{BigIntString, IdentifierLikeNAPI, TryToU64};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::identifier::IdentifierNAPI;
 use crate::state_transition::StateTransitionNAPI;
 use crate::utils::{WithJsError, js_outputs_to_outputs};
@@ -142,6 +145,19 @@ impl IdentityCreditTransferToAddressesTransitionNAPI {
     #[napi(setter, js_name = "signature")]
     pub fn set_signature(&mut self, signature: Uint8Array) {
         self.0.set_signature_bytes(signature.to_vec())
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/address_transitions/top_up_from_address.rs
+++ b/src/address_transitions/top_up_from_address.rs
@@ -7,8 +7,10 @@ use dpp::state_transition::identity_topup_from_addresses_transition::IdentityTop
 use dpp::state_transition::identity_topup_from_addresses_transition::accessors::IdentityTopUpFromAddressesTransitionAccessorsV0;
 use dpp::state_transition::identity_topup_from_addresses_transition::v0::IdentityTopUpFromAddressesTransitionV0;
 use dpp::state_transition::{
-    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionWitnessSigned,
+    StateTransition, StateTransitionAddressesFeeStrategy, StateTransitionEstimatedFeeValidation,
+    StateTransitionWitnessSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
@@ -17,6 +19,7 @@ use crate::address_transitions::entities::input_address::InputAddressNAPI;
 use crate::address_transitions::entities::output_address::OutputAddressNAPI;
 use crate::dynamic_value::TryToU64;
 use crate::dynamic_value::{BigIntString, IdentifierLikeNAPI};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::identifier::IdentifierNAPI;
 use crate::platform_address::address_witness::AddressWitnessNAPI;
 use crate::state_transition::StateTransitionNAPI;
@@ -179,6 +182,19 @@ impl IdentityTopUpFromAddressesTransitionNAPI {
         self.0.set_witnesses(input_witnesses);
 
         Ok(())
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -2,6 +2,7 @@ use dpp::platform_value::BinaryData;
 use dpp::platform_value::string_encoding::Encoding::{Base64, Hex};
 use dpp::platform_value::string_encoding::{decode, encode};
 use dpp::serialization::{PlatformDeserializable, PlatformSerializable};
+use dpp::state_transition::StateTransitionEstimatedFeeValidation;
 use dpp::state_transition::batch_transition::accessors::DocumentsBatchTransitionAccessorsV0;
 use dpp::state_transition::batch_transition::batched_transition::BatchedTransition;
 use dpp::state_transition::batch_transition::batched_transition::document_transition::DocumentTransition;
@@ -13,12 +14,14 @@ use dpp::state_transition::{
     StateTransition, StateTransitionIdentitySigned, StateTransitionLike, StateTransitionOwned,
     StateTransitionSingleSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::batch::batched_transition::BatchedTransitionNAPI;
 use crate::batch::document_transition::DocumentTransitionNAPI;
 use crate::dynamic_value::{BigIntString, IdentifierLikeNAPI, TryToU64};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::identifier::IdentifierNAPI;
 use crate::state_transition::StateTransitionNAPI;
 use crate::utils::WithJsError;
@@ -205,6 +208,19 @@ impl BatchTransitionNAPI {
                 "Invalid state document_transition content",
             )),
         }
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/data_contract_transitions/create/mod.rs
+++ b/src/data_contract_transitions/create/mod.rs
@@ -5,11 +5,13 @@ use dpp::platform_value::string_encoding::{decode, encode};
 use dpp::prelude::DataContract;
 use dpp::serialization::{PlatformDeserializable, PlatformSerializable};
 use dpp::state_transition::StateTransition;
+use dpp::state_transition::StateTransitionEstimatedFeeValidation;
 use dpp::state_transition::data_contract_create_transition::accessors::DataContractCreateTransitionAccessorsV0;
 use dpp::state_transition::data_contract_create_transition::{
     DataContractCreateTransition, DataContractCreateTransitionV0,
 };
 use dpp::validation::operations::ProtocolValidationOperation;
+use dpp::version::PlatformVersion;
 use dpp::version::{TryFromPlatformVersioned, TryIntoPlatformVersioned};
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
@@ -85,6 +87,19 @@ impl DataContractCreateTransitionNAPI {
             .map_err(|err| napi::Error::new(napi::Status::GenericFailure, err.to_string()))?;
 
         DataContractCreateTransitionNAPI::from_bytes(bytes.into())
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/data_contract_transitions/update/mod.rs
+++ b/src/data_contract_transitions/update/mod.rs
@@ -4,9 +4,11 @@ use dpp::platform_value::string_encoding::{decode, encode};
 use dpp::prelude::DataContract;
 use dpp::serialization::{PlatformDeserializable, PlatformSerializable};
 use dpp::state_transition::StateTransition;
+use dpp::state_transition::StateTransitionEstimatedFeeValidation;
 use dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
 use dpp::state_transition::data_contract_update_transition::accessors::DataContractUpdateTransitionAccessorsV0;
 use dpp::validation::operations::ProtocolValidationOperation;
+use dpp::version::PlatformVersion;
 use dpp::version::TryFromPlatformVersioned;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
@@ -70,6 +72,19 @@ impl DataContractUpdateTransitionNAPI {
             .map_err(|err| napi::Error::new(napi::Status::GenericFailure, err.to_string()))?;
 
         DataContractUpdateTransitionNAPI::from_bytes(bytes.into())
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/identity_transitions/credit_withdrawal_transition/mod.rs
+++ b/src/identity_transitions/credit_withdrawal_transition/mod.rs
@@ -4,6 +4,7 @@ use dpp::platform_value::Identifier;
 use dpp::platform_value::string_encoding::Encoding::{Base64, Hex};
 use dpp::platform_value::string_encoding::{decode, encode};
 use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable};
+use dpp::state_transition::StateTransitionEstimatedFeeValidation;
 use dpp::state_transition::StateTransitionHasUserFeeIncrease;
 use dpp::state_transition::identity_credit_withdrawal_transition::IdentityCreditWithdrawalTransition;
 use dpp::state_transition::identity_credit_withdrawal_transition::accessors::IdentityCreditWithdrawalTransitionAccessorsV0;
@@ -12,12 +13,14 @@ use dpp::state_transition::{
     StateTransition, StateTransitionIdentitySigned, StateTransitionLike,
     StateTransitionSingleSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::asset_lock_proof::AssetLockProofNAPI;
 use crate::core_script::CoreScriptNAPI;
 use crate::dynamic_value::{BigIntString, DynamicValue, IdentifierLikeNAPI, TryToU64};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::enums::pooling::PoolingNAPI;
 use crate::enums::purpose::PurposeNAPI;
 use crate::identifier::IdentifierNAPI;
@@ -207,6 +210,19 @@ impl IdentityCreditWithdrawalTransitionNAPI {
             .map_err(|err| napi::Error::new(napi::Status::InvalidArg, err.to_string()))?;
 
         IdentityCreditWithdrawalTransitionNAPI::from_bytes(bytes.into())
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/identity_transitions/identitiy_credit_transfer_transition/mod.rs
+++ b/src/identity_transitions/identitiy_credit_transfer_transition/mod.rs
@@ -3,6 +3,7 @@ use dpp::platform_value::string_encoding::Encoding::{Base64, Hex};
 use dpp::platform_value::string_encoding::{decode, encode};
 use dpp::prelude::Identifier;
 use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable};
+use dpp::state_transition::StateTransitionEstimatedFeeValidation;
 use dpp::state_transition::identity_credit_transfer_transition::IdentityCreditTransferTransition;
 use dpp::state_transition::identity_credit_transfer_transition::accessors::IdentityCreditTransferTransitionAccessorsV0;
 use dpp::state_transition::identity_credit_transfer_transition::v0::IdentityCreditTransferTransitionV0;
@@ -10,10 +11,12 @@ use dpp::state_transition::{
     StateTransition, StateTransitionHasUserFeeIncrease, StateTransitionIdentitySigned,
     StateTransitionSingleSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::dynamic_value::{BigIntString, IdentifierLikeNAPI, TryToU64};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::identifier::IdentifierNAPI;
 use crate::state_transition::StateTransitionNAPI;
 use crate::utils::WithJsError;
@@ -47,6 +50,19 @@ impl IdentityCreditTransferNAPI {
                 signature: Default::default(),
             }),
         ))
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/identity_transitions/identity_create_transition/mod.rs
+++ b/src/identity_transitions/identity_create_transition/mod.rs
@@ -3,17 +3,21 @@ use dpp::platform_value::BinaryData;
 use dpp::platform_value::string_encoding::Encoding::{Base64, Hex};
 use dpp::platform_value::string_encoding::decode;
 use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable};
+use dpp::state_transition::StateTransitionEstimatedFeeValidation;
 use dpp::state_transition::StateTransitionHasUserFeeIncrease;
 use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
 use dpp::state_transition::identity_create_transition::accessors::IdentityCreateTransitionAccessorsV0;
 use dpp::state_transition::identity_create_transition::v0::IdentityCreateTransitionV0;
 use dpp::state_transition::public_key_in_creation::IdentityPublicKeyInCreation;
 use dpp::state_transition::{StateTransition, StateTransitionSingleSigned};
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::asset_lock_proof::AssetLockProofNAPI;
+use crate::dynamic_value::BigIntString;
 use crate::dynamic_value::DynamicValue;
+use crate::dynamic_value::TryToU64;
 use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::identifier::IdentifierNAPI;
 use crate::identity_public_key_in_creation::IdentityPublicKeyInCreationNAPI;
@@ -84,6 +88,19 @@ impl IdentityCreateTransitionNAPI {
             .map_err(|err| napi::Error::new(napi::Status::GenericFailure, err.to_string()))?;
 
         IdentityCreateTransitionNAPI::from_bytes(bytes.into())
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/identity_transitions/identity_top_up_transition/mod.rs
+++ b/src/identity_transitions/identity_top_up_transition/mod.rs
@@ -3,16 +3,21 @@ use dpp::identity::state_transition::{AssetLockProved, OptionallyAssetLockProved
 use dpp::platform_value::string_encoding::Encoding::{Base64, Hex};
 use dpp::platform_value::string_encoding::{decode, encode};
 use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable};
+use dpp::state_transition::StateTransitionEstimatedFeeValidation;
 use dpp::state_transition::StateTransitionHasUserFeeIncrease;
 use dpp::state_transition::identity_topup_transition::IdentityTopUpTransition;
 use dpp::state_transition::identity_topup_transition::accessors::IdentityTopUpTransitionAccessorsV0;
 use dpp::state_transition::identity_topup_transition::v0::IdentityTopUpTransitionV0;
 use dpp::state_transition::{StateTransition, StateTransitionLike, StateTransitionSingleSigned};
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::asset_lock_proof::AssetLockProofNAPI;
+use crate::dynamic_value::BigIntString;
 use crate::dynamic_value::IdentifierLikeNAPI;
+use crate::dynamic_value::TryToU64;
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::identifier::IdentifierNAPI;
 use crate::state_transition::StateTransitionNAPI;
 use crate::utils::WithJsError;
@@ -110,6 +115,19 @@ impl IdentityTopUpTransitionNAPI {
     #[napi(setter, js_name = "signature")]
     pub fn set_signature(&mut self, signature: Uint8Array) {
         self.0.set_signature_bytes(signature.to_vec())
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/identity_transitions/identity_update_transition/mod.rs
+++ b/src/identity_transitions/identity_update_transition/mod.rs
@@ -2,6 +2,7 @@ use dpp::identity::state_transition::OptionallyAssetLockProved;
 use dpp::platform_value::string_encoding::Encoding::{Base64, Hex};
 use dpp::platform_value::string_encoding::{decode, encode};
 use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable};
+use dpp::state_transition::StateTransitionEstimatedFeeValidation;
 use dpp::state_transition::StateTransitionHasUserFeeIncrease;
 use dpp::state_transition::identity_update_transition::IdentityUpdateTransition;
 use dpp::state_transition::identity_update_transition::accessors::IdentityUpdateTransitionAccessorsV0;
@@ -11,11 +12,13 @@ use dpp::state_transition::{
     StateTransition, StateTransitionIdentitySigned, StateTransitionLike,
     StateTransitionSingleSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::asset_lock_proof::AssetLockProofNAPI;
 use crate::dynamic_value::{BigIntString, IdentifierLikeNAPI, TryToU64};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::enums::purpose::PurposeNAPI;
 use crate::identifier::IdentifierNAPI;
 use crate::identity_public_key_in_creation::IdentityPublicKeyInCreationNAPI;
@@ -200,6 +203,19 @@ impl IdentityUpdateTransitionNAPI {
             .map_err(|err| napi::Error::new(napi::Status::InvalidArg, err.to_string()))?;
 
         IdentityUpdateTransitionNAPI::from_bytes(bytes.into())
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/masternode_vote/mod.rs
+++ b/src/masternode_vote/mod.rs
@@ -7,6 +7,7 @@ use dpp::platform_value::BinaryData;
 use dpp::platform_value::string_encoding::Encoding::{self, Base64, Hex};
 use dpp::platform_value::string_encoding::{decode, encode};
 use dpp::serialization::{PlatformDeserializable, PlatformSerializable, Signable};
+use dpp::state_transition::StateTransitionEstimatedFeeValidation;
 use dpp::state_transition::masternode_vote_transition::MasternodeVoteTransition;
 use dpp::state_transition::masternode_vote_transition::accessors::MasternodeVoteTransitionAccessorsV0;
 use dpp::state_transition::masternode_vote_transition::v0::MasternodeVoteTransitionV0;
@@ -14,11 +15,13 @@ use dpp::state_transition::{
     StateTransition, StateTransitionIdentitySigned, StateTransitionLike,
     StateTransitionSingleSigned,
 };
+use dpp::version::PlatformVersion;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
 use crate::asset_lock_proof::AssetLockProofNAPI;
 use crate::dynamic_value::{BigIntString, IdentifierLikeNAPI, TryToU64};
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::identifier::IdentifierNAPI;
 use crate::masternode_vote::vote::VoteNAPI;
 use crate::state_transition::StateTransitionNAPI;
@@ -162,6 +165,19 @@ impl MasternodeVoteTransitionNAPI {
             .map_err(|_| napi::Error::new(napi::Status::InvalidArg, "Invalid base64 string"))?;
 
         MasternodeVoteTransitionNAPI::from_bytes(bytes.into())
+    }
+
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        self.0
+            .calculate_min_required_fee(&platform_version)
+            .map(BigIntString::from_u64)
+            .with_js_error()
     }
 
     #[napi(js_name = "bytes")]

--- a/src/orchard/memo.rs
+++ b/src/orchard/memo.rs
@@ -22,14 +22,10 @@ impl From<ShieldedMemoNAPI> for ShieldedMemo {
 impl ShieldedMemoNAPI {
     #[napi(js_name = "fromString")]
     pub fn from_string(value: String) -> Result<Self, napi::Error> {
-        if value.len() != MEMO_PAYLOAD_SIZE {
-            return Err(napi::Error::new(
-                napi::Status::InvalidArg,
-                format!("Memo payload must be {MEMO_PAYLOAD_SIZE}"),
-            ));
-        }
-
-        Ok(ShieldedMemoNAPI(ShieldedMemo::Text(value)))
+        // Delegate so the length rule stays defined in exactly one place.
+        ShieldedMemo::text(value)
+            .map(ShieldedMemoNAPI)
+            .map_err(|error| napi::Error::new(napi::Status::InvalidArg, error.to_string()))
     }
 
     #[napi(js_name = "empty")]
@@ -42,7 +38,10 @@ impl ShieldedMemoNAPI {
         if payload.len() != MEMO_PAYLOAD_SIZE {
             return Err(napi::Error::new(
                 napi::Status::InvalidArg,
-                format!("Memo payload must be {MEMO_PAYLOAD_SIZE}"),
+                format!(
+                    "Memo payload must be exactly {MEMO_PAYLOAD_SIZE} bytes, got {}",
+                    payload.len()
+                ),
             ));
         }
 
@@ -54,14 +53,14 @@ impl ShieldedMemoNAPI {
 
     #[napi(js_name = "toString")]
     pub fn to_string(&self) -> Result<String, napi::Error> {
-        Ok(str::from_utf8(&self.0.to_bytes().clone())
-            .map_err(|_| {
-                napi::Error::new(
-                    napi::Status::GenericFailure,
-                    "cannot convert bytes to utf-8",
-                )
-            })?
-            .to_string())
+        match &self.0 {
+            ShieldedMemo::Empty => Ok(String::new()),
+            ShieldedMemo::Text(text) => Ok(text.clone()),
+            ShieldedMemo::Other { kind, .. } => Err(napi::Error::new(
+                napi::Status::GenericFailure,
+                format!("memo of kind {kind} is not text; use toBytes instead"),
+            )),
+        }
     }
 
     #[napi(js_name = "toBytes")]

--- a/src/platform_address/mod.rs
+++ b/src/platform_address/mod.rs
@@ -1,14 +1,24 @@
 pub mod address_witness;
 
 use dpp::address_funds::PlatformAddress;
+use dpp::version::PlatformVersion;
 use napi::{Either, bindgen_prelude::Uint8Array};
 use napi_derive::napi;
 
 use crate::{
-    dynamic_value::{DynamicValue, PlatformAddressLikeNAPI},
+    dynamic_value::{BigIntString, DynamicValue, PlatformAddressLikeNAPI, TryToU64},
     enums::network::NetworkNAPI,
+    enums::platform_version::PlatformVersionNAPI,
     utils::WithJsError,
 };
+
+/// Bytes GroveDB charges when a platform address balance entry is created.
+///
+/// Not a dpp constant: it is the size the node's own fee regression suite pins down — a transfer
+/// to one address that is not in state is charged 6_075_000 credits of storage, which is this
+/// many bytes at `storage_disk_usage_credit_per_byte` (27_000). Paying an address that already
+/// exists only updates a sum item and adds no bytes.
+const PLATFORM_ADDRESS_STORAGE_BYTES: u64 = 225;
 
 #[derive(Clone)]
 #[napi(js_name = "PlatformAddressNAPI")]
@@ -58,6 +68,33 @@ impl PlatformAddressNAPI {
     #[napi(js_name = "bytes")]
     pub fn address(&self) -> Uint8Array {
         Uint8Array::from(self.0.to_bytes())
+    }
+
+    /// Storage fee GroveDB charges for creating balance entries for addresses that are not in
+    /// state yet.
+    ///
+    /// Minimum fees price a transition as if every one of its outputs pays a fresh address, but
+    /// the fee actually charged is metered: paying an address that already exists writes no new
+    /// bytes and costs (close to) nothing in storage, while every address created costs
+    /// `PLATFORM_ADDRESS_STORAGE_BYTES` at the disk rate. Add this to a processing estimate when
+    /// you know how many of your outputs are new.
+    #[napi(js_name = "estimateStorageFeeForNewAddresses")]
+    pub fn estimate_storage_fee_for_new_addresses(
+        js_address_count: u32,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> BigIntString {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        BigIntString::from_u64(
+            PLATFORM_ADDRESS_STORAGE_BYTES
+                .saturating_mul(
+                    platform_version
+                        .fee_version
+                        .storage
+                        .storage_disk_usage_credit_per_byte,
+                )
+                .saturating_mul(js_address_count as u64),
+        )
     }
 
     #[napi(js_name = "toAddress")]

--- a/src/state_transition/mod.rs
+++ b/src/state_transition/mod.rs
@@ -29,8 +29,10 @@ use dpp::state_transition::identity_update_transition::accessors::IdentityUpdate
 use dpp::state_transition::masternode_vote_transition::MasternodeVoteTransition;
 use dpp::state_transition::masternode_vote_transition::accessors::MasternodeVoteTransitionAccessorsV0;
 use dpp::state_transition::{
-    StateTransition, StateTransitionIdentitySigned, StateTransitionSigningOptions,
+    StateTransition, StateTransitionEstimatedFeeValidation, StateTransitionIdentitySigned,
+    StateTransitionSigningOptions,
 };
+use dpp::version::PlatformVersion;
 use napi::Either;
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
@@ -38,6 +40,7 @@ use sha2::{Digest, Sha256};
 
 use crate::dynamic_value::{BigIntString, DynamicValue, IdentifierLikeNAPI, TryToU64};
 use crate::enums::key_type::KeyTypeNAPI;
+use crate::enums::platform_version::PlatformVersionNAPI;
 use crate::enums::purpose::PurposeNAPI;
 use crate::enums::security_level::SecurityLevelNAPI;
 use crate::identifier::IdentifierNAPI;
@@ -296,6 +299,56 @@ impl StateTransitionNAPI {
     #[napi(js_name = "getActionName")]
     pub fn get_action_name(&self) -> String {
         self.0.name()
+    }
+
+    /// The minimum fee the network requires for this transition to be accepted.
+    ///
+    /// This is the same value the node checks the payer balance against before execution.
+    /// The fee actually charged is metered during execution and depends on state (for
+    /// example, paying an address that does not exist yet adds storage cost), so it can
+    /// be higher than this minimum.
+    #[napi(js_name = "calculateMinRequiredFee")]
+    pub fn calculate_min_required_fee(
+        &self,
+        js_platform_version: Option<PlatformVersionNAPI>,
+    ) -> Result<BigIntString, napi::Error> {
+        let platform_version: PlatformVersion = js_platform_version.unwrap_or_default().into();
+
+        let fee = match &self.0 {
+            DataContractCreate(st) => st.calculate_min_required_fee(&platform_version),
+            DataContractUpdate(st) => st.calculate_min_required_fee(&platform_version),
+            Batch(st) => st.calculate_min_required_fee(&platform_version),
+            StateTransition::IdentityCreate(st) => st.calculate_min_required_fee(&platform_version),
+            IdentityTopUp(st) => st.calculate_min_required_fee(&platform_version),
+            IdentityUpdate(st) => st.calculate_min_required_fee(&platform_version),
+            IdentityCreditWithdrawal(st) => st.calculate_min_required_fee(&platform_version),
+            IdentityCreditTransfer(st) => st.calculate_min_required_fee(&platform_version),
+            MasternodeVote(st) => st.calculate_min_required_fee(&platform_version),
+            IdentityCreditTransferToAddresses(st) => {
+                st.calculate_min_required_fee(&platform_version)
+            }
+            IdentityCreateFromAddresses(st) => st.calculate_min_required_fee(&platform_version),
+            IdentityTopUpFromAddresses(st) => st.calculate_min_required_fee(&platform_version),
+            AddressFundsTransfer(st) => st.calculate_min_required_fee(&platform_version),
+            AddressFundingFromAssetLock(st) => st.calculate_min_required_fee(&platform_version),
+            AddressCreditWithdrawal(st) => st.calculate_min_required_fee(&platform_version),
+            StateTransition::Shield(st) => st.calculate_min_required_fee(&platform_version),
+            StateTransition::ShieldedTransfer(st) => {
+                st.calculate_min_required_fee(&platform_version)
+            }
+            StateTransition::Unshield(st) => st.calculate_min_required_fee(&platform_version),
+            StateTransition::ShieldFromAssetLock(st) => {
+                st.calculate_min_required_fee(&platform_version)
+            }
+            StateTransition::ShieldedWithdrawal(st) => {
+                st.calculate_min_required_fee(&platform_version)
+            }
+            StateTransition::IdentityCreateFromShieldedPool(st) => {
+                st.calculate_min_required_fee(&platform_version)
+            }
+        };
+
+        fee.map(BigIntString::from_u64).with_js_error()
     }
 
     #[napi(js_name = "getActionType")]

--- a/templates/binaries/node.cjs
+++ b/templates/binaries/node.cjs
@@ -13,7 +13,7 @@ function isMusl() {
     return false;
   }
 }
-function getBinaryPath() {
+function getTarget() {
   const platform = process.platform;
   const arch = process.arch;
   let target = '';
@@ -43,7 +43,7 @@ function getBinaryPath() {
     console.error(`Unsupported platform: ${platform} ${arch}. Using WebAssembly instead Node-API`);
     return null;
   }
-  return path.join('native', target, 'pshenmic_dpp.node');
+  return target;
 }
 
 // The native addon can be unusable even on a supported platform: the binary may
@@ -52,20 +52,20 @@ function getBinaryPath() {
 // should be fatal — WebAssembly is a complete fallback, so any load failure
 // degrades to it instead of taking the whole import down.
 function loadNative() {
-  const binaryPath = getBinaryPath();
-  if (binaryPath === null) {
+  const target = getTarget();
+  if (target === null) {
     return null;
   }
   try {
-    const nativeModule = require(`./${binaryPath}`);
-    console.log(`running on native dpp (${binaryPath})`);
+    const nativeModule = require(`./${path.join('native', target, 'pshenmic_dpp.node')}`);
+    console.log(`running on native dpp (${target})`);
     return nativeModule;
   }
   catch (error) {
     // Only the first line: node appends a multi-line "Require stack" to
     // MODULE_NOT_FOUND messages, which buries the actual reason.
     const reason = String(error?.message ?? error).split('\n')[0];
-    console.error(`Failed to load native dpp (${binaryPath}): ${reason}. Using WebAssembly instead Node-API`);
+    console.error(`Failed to load native dpp (${target}): ${reason}. Using WebAssembly instead Node-API`);
     return null;
   }
 }

--- a/templates/binaries/node.cjs
+++ b/templates/binaries/node.cjs
@@ -3,8 +3,15 @@ const path = require('node:path');
 function isMusl() {
   if (process.platform !== 'linux')
     return false;
-  const report = process.report?.getReport?.();
-  return !report?.header?.glibcVersionRuntime;
+  try {
+    const report = process.report?.getReport?.();
+    return !report?.header?.glibcVersionRuntime;
+  }
+  catch {
+    // getReport() is unavailable in some embedders/worker contexts; assume
+    // glibc, and let the require below fall back to WebAssembly if wrong.
+    return false;
+  }
 }
 function getBinaryPath() {
   const platform = process.platform;
@@ -24,27 +31,43 @@ function getBinaryPath() {
       target = `x86_64-unknown-linux-${libc}`;
     }
   }
-  // else if (platform === 'win32') {
-  //   if (arch === 'arm64') {
-  //     target = 'aarch64-pc-windows-msvc';
-  //   }
-  //   else {
-  //     target = 'x86_64-pc-windows-msvc';
-  //   }
-  // }
+  else if (platform === 'win32') {
+    if (arch === 'arm64') {
+      target = 'aarch64-pc-windows-msvc';
+    }
+    else {
+      target = 'x86_64-pc-windows-msvc';
+    }
+  }
   else {
     console.error(`Unsupported platform: ${platform} ${arch}. Using WebAssembly instead Node-API`);
     return null;
   }
-  console.log(`running on native dpp (${target})`);
   return path.join('native', target, 'pshenmic_dpp.node');
 }
-const binaryPath = getBinaryPath();
-let exportedModule;
-if (binaryPath !== null) {
-  exportedModule = require(`./${binaryPath}`);
+
+// The native addon can be unusable even on a supported platform: the binary may
+// be missing from the package, built for another libc/arch, or fail to link
+// against a system dependency (e.g. the VC++ runtime on Windows). None of that
+// should be fatal — WebAssembly is a complete fallback, so any load failure
+// degrades to it instead of taking the whole import down.
+function loadNative() {
+  const binaryPath = getBinaryPath();
+  if (binaryPath === null) {
+    return null;
+  }
+  try {
+    const nativeModule = require(`./${binaryPath}`);
+    console.log(`running on native dpp (${binaryPath})`);
+    return nativeModule;
+  }
+  catch (error) {
+    // Only the first line: node appends a multi-line "Require stack" to
+    // MODULE_NOT_FOUND messages, which buries the actual reason.
+    const reason = String(error?.message ?? error).split('\n')[0];
+    console.error(`Failed to load native dpp (${binaryPath}): ${reason}. Using WebAssembly instead Node-API`);
+    return null;
+  }
 }
-else {
-  exportedModule = require('./wasmCreation.cjs');
-}
-module.exports = exportedModule;
+
+module.exports = loadNative() ?? require('./wasmCreation.cjs');

--- a/tests/unit/AddressTransitionsFees.spec.ts
+++ b/tests/unit/AddressTransitionsFees.spec.ts
@@ -1,0 +1,274 @@
+import {
+  AddressCreditWithdrawalTransitionWASM,
+  AddressFundingFromAssetLockTransitionWASM,
+  AddressFundsFeeStrategyStepWASM,
+  AddressFundsTransferTransitionWASM,
+  AddressWitnessWASM,
+  AssetLockProofWASM,
+  CoreScriptWASM,
+  IdentityCreateFromAddressesTransitionWASM,
+  IdentityCreditTransferToAddressesTransitionWASM,
+  IdentityPublicKeyInCreationWASM,
+  IdentityTopUpFromAddressesTransitionWASM,
+  InputAddressWASM,
+  KeyType,
+  OutPointWASM,
+  OutputAddressNullableCreditsWASM,
+  OutputAddressWASM,
+  PlatformAddressWASM,
+  PlatformVersionWASM,
+  Purpose,
+  SecurityLevel
+} from 'pshenmic-dpp'
+
+// Min fee components from the platform fee version (STATE_TRANSITION_MIN_FEES_VERSION1)
+// Storage charged by the node for one address balance entry that does not exist yet,
+// as pinned by platform's own fee regression suite.
+const NEW_ADDRESS_STORAGE_FEE = BigInt(6075000)
+const INPUT_COST = BigInt(500000)
+const OUTPUT_COST = BigInt(6000000)
+const ADDRESS_CREDIT_WITHDRAWAL_COST = BigInt(400000000)
+const IDENTITY_CREATE_BASE_COST = BigInt(2000000)
+const IDENTITY_KEY_IN_CREATION_COST = BigInt(6500000)
+const IDENTITY_TOPUP_BASE_COST = BigInt(500000)
+const CREDIT_TRANSFER_TO_ADDRESSES_COST = BigInt(500000)
+
+function randomBytes (length: number): Uint8Array {
+  const bytes = new Uint8Array(length)
+  for (let i = 0; i < length; i++) {
+    bytes[i] = Math.floor(Math.random() * 256)
+  }
+  return bytes
+}
+
+function createTestAddress (): PlatformAddressWASM {
+  const addressBytes = new Uint8Array(21)
+  addressBytes[0] = 0x00
+  addressBytes.set(randomBytes(20), 1)
+  return PlatformAddressWASM.fromBytes(addressBytes)
+}
+
+function createTestInputs (count: number): InputAddressWASM[] {
+  return Array.from(
+    { length: count },
+    () => new InputAddressWASM(createTestAddress(), 0, BigInt(500000000))
+  )
+}
+
+function createTestOutputs (count: number): OutputAddressWASM[] {
+  return Array.from(
+    { length: count },
+    () => new OutputAddressWASM(createTestAddress(), BigInt(100000))
+  )
+}
+
+function createTestWitnesses (count: number): AddressWitnessWASM[] {
+  return Array.from({ length: count }, () => AddressWitnessWASM.P2PKH(randomBytes(65)))
+}
+
+const feeStrategy = (): AddressFundsFeeStrategyStepWASM[] =>
+  [AddressFundsFeeStrategyStepWASM.DeductFromInput(0)]
+
+describe('AddressFundsTransferTransition fees', function () {
+  describe('estimateMinFee', function () {
+    test('should price inputs and outputs', function () {
+      expect(AddressFundsTransferTransitionWASM.estimateMinFee(1, 1))
+        .toEqual(INPUT_COST + OUTPUT_COST)
+
+      expect(AddressFundsTransferTransitionWASM.estimateMinFee(2, 3))
+        .toEqual(INPUT_COST * BigInt(2) + OUTPUT_COST * BigInt(3))
+    })
+
+    test('should charge at least one output', function () {
+      expect(AddressFundsTransferTransitionWASM.estimateMinFee(1, 0))
+        .toEqual(AddressFundsTransferTransitionWASM.estimateMinFee(1, 1))
+    })
+
+    test('should grow with the input and output counts', function () {
+      const one = AddressFundsTransferTransitionWASM.estimateMinFee(1, 1)
+      const two = AddressFundsTransferTransitionWASM.estimateMinFee(2, 2)
+
+      expect(two).toBeGreaterThan(one)
+    })
+
+    test('should default to the latest platform version', function () {
+      expect(AddressFundsTransferTransitionWASM.estimateMinFee(1, 1))
+        .toEqual(AddressFundsTransferTransitionWASM.estimateMinFee(1, 1, PlatformVersionWASM.PLATFORM_V13))
+    })
+  })
+
+  describe('calculateMinRequiredFee', function () {
+    test('should match the estimate for the transition inputs and outputs', function () {
+      const transition = new AddressFundsTransferTransitionWASM(
+        createTestInputs(2),
+        feeStrategy(),
+        0,
+        createTestWitnesses(2),
+        createTestOutputs(1)
+      )
+
+      expect(transition.calculateMinRequiredFee())
+        .toEqual(AddressFundsTransferTransitionWASM.estimateMinFee(2, 1))
+    })
+  })
+})
+
+describe('AddressCreditWithdrawalTransition fees', function () {
+  const outputScript = (): CoreScriptWASM => CoreScriptWASM.newP2PKH(randomBytes(20))
+
+  describe('estimateMinFee', function () {
+    test('should price the withdrawal, its inputs and its change output', function () {
+      expect(AddressCreditWithdrawalTransitionWASM.estimateMinFee(1, false))
+        .toEqual(ADDRESS_CREDIT_WITHDRAWAL_COST + INPUT_COST)
+
+      expect(AddressCreditWithdrawalTransitionWASM.estimateMinFee(1, true))
+        .toEqual(ADDRESS_CREDIT_WITHDRAWAL_COST + INPUT_COST + OUTPUT_COST)
+    })
+
+    test('should grow with the input count', function () {
+      expect(AddressCreditWithdrawalTransitionWASM.estimateMinFee(2, false))
+        .toBeGreaterThan(AddressCreditWithdrawalTransitionWASM.estimateMinFee(1, false))
+    })
+  })
+
+  describe('calculateMinRequiredFee', function () {
+    test('should match the estimate without a change output', function () {
+      const transition = new AddressCreditWithdrawalTransitionWASM(
+        createTestInputs(1),
+        feeStrategy(),
+        1,
+        'Standard',
+        outputScript(),
+        0,
+        createTestWitnesses(1)
+      )
+
+      expect(transition.calculateMinRequiredFee())
+        .toEqual(AddressCreditWithdrawalTransitionWASM.estimateMinFee(1, false))
+    })
+
+    test('should match the estimate with a change output', function () {
+      const transition = new AddressCreditWithdrawalTransitionWASM(
+        createTestInputs(1),
+        feeStrategy(),
+        1,
+        'Standard',
+        outputScript(),
+        0,
+        createTestWitnesses(1),
+        createTestOutputs(1)[0]
+      )
+
+      expect(transition.calculateMinRequiredFee())
+        .toEqual(AddressCreditWithdrawalTransitionWASM.estimateMinFee(1, true))
+    })
+  })
+})
+
+describe('IdentityCreateFromAddressesTransition fees', function () {
+  test('calculateMinRequiredFee should price the base cost, inputs, output and keys', function () {
+    const publicKeys = [
+      new IdentityPublicKeyInCreationWASM(
+        0,
+        Purpose.AUTHENTICATION,
+        SecurityLevel.MASTER,
+        KeyType.ECDSA_SECP256K1,
+        false,
+        randomBytes(33)
+      )
+    ]
+
+    const transition = new IdentityCreateFromAddressesTransitionWASM(
+      publicKeys,
+      createTestInputs(1),
+      feeStrategy(),
+      0,
+      createTestWitnesses(1),
+      createTestOutputs(1)[0]
+    )
+
+    expect(transition.calculateMinRequiredFee()).toEqual(
+      IDENTITY_CREATE_BASE_COST + INPUT_COST + OUTPUT_COST + IDENTITY_KEY_IN_CREATION_COST
+    )
+  })
+})
+
+describe('IdentityTopUpFromAddressesTransition fees', function () {
+  test('calculateMinRequiredFee should price the base cost, inputs and output', function () {
+    const transition = new IdentityTopUpFromAddressesTransitionWASM(
+      randomBytes(32),
+      createTestInputs(1),
+      feeStrategy(),
+      0,
+      createTestWitnesses(1),
+      createTestOutputs(1)[0]
+    )
+
+    expect(transition.calculateMinRequiredFee())
+      .toEqual(IDENTITY_TOPUP_BASE_COST + INPUT_COST + OUTPUT_COST)
+  })
+})
+
+describe('IdentityCreditTransferToAddressesTransition fees', function () {
+  test('calculateMinRequiredFee should price the base cost and each recipient', function () {
+    const transition = new IdentityCreditTransferToAddressesTransitionWASM(
+      randomBytes(32),
+      createTestOutputs(2),
+      BigInt(1),
+      0
+    )
+
+    expect(transition.calculateMinRequiredFee())
+      .toEqual(CREDIT_TRANSFER_TO_ADDRESSES_COST + OUTPUT_COST * BigInt(2))
+  })
+})
+
+describe('AddressFundingFromAssetLockTransition fees', function () {
+  test('calculateMinRequiredFee should include the asset lock base cost', function () {
+    const outPoint = new OutPointWASM('a'.repeat(64), 0)
+    const assetLockProof = AssetLockProofWASM.createChainAssetLockProof(100, outPoint)
+
+    const transition = new AddressFundingFromAssetLockTransitionWASM(
+      assetLockProof,
+      createTestInputs(1),
+      feeStrategy(),
+      0,
+      createTestWitnesses(1),
+      [new OutputAddressNullableCreditsWASM(createTestAddress(), BigInt(100000))]
+    )
+
+    const fee = transition.calculateMinRequiredFee()
+
+    expect(typeof fee).toEqual('bigint')
+    expect(fee).toBeGreaterThan(INPUT_COST + OUTPUT_COST)
+  })
+})
+
+describe('new address storage fee', function () {
+  test('should match the storage the node charges for one created address', function () {
+    expect(PlatformAddressWASM.estimateStorageFeeForNewAddresses(1))
+      .toEqual(NEW_ADDRESS_STORAGE_FEE)
+  })
+
+  test('should scale with the number of created addresses', function () {
+    expect(PlatformAddressWASM.estimateStorageFeeForNewAddresses(0)).toEqual(BigInt(0))
+    expect(PlatformAddressWASM.estimateStorageFeeForNewAddresses(3))
+      .toEqual(NEW_ADDRESS_STORAGE_FEE * BigInt(3))
+  })
+
+  test('should default to the latest platform version', function () {
+    expect(PlatformAddressWASM.estimateStorageFeeForNewAddresses(1))
+      .toEqual(PlatformAddressWASM.estimateStorageFeeForNewAddresses(1, PlatformVersionWASM.PLATFORM_V13))
+  })
+
+  test('should exceed the per output component of the min fee', function () {
+    const perOutput =
+      AddressFundsTransferTransitionWASM.estimateMinFee(1, 2) -
+      AddressFundsTransferTransitionWASM.estimateMinFee(1, 1)
+
+    // The min fee prices an output slightly below what a created address costs in storage,
+    // which is why a transfer paying a brand new address is charged a little more than its
+    // minimum required fee.
+    expect(NEW_ADDRESS_STORAGE_FEE).toBeGreaterThan(perOutput)
+  })
+})

--- a/tests/unit/Shielded.spec.ts
+++ b/tests/unit/Shielded.spec.ts
@@ -27,7 +27,9 @@ const ACCOUNT = 0
 // A funded testnet WIF reused across the builder/deposit tests.
 const WIF = 'cUy4wbim4y9NDwC24omx8oWY5WqfmjSU2gdcZtTXza2xDCAkQXRP'
 
-// Memo payloads are a fixed 32 bytes (MEMO_PAYLOAD_SIZE).
+// The memo payload field is a fixed 32 bytes (MEMO_PAYLOAD_SIZE) on the wire.
+// Text memos may be shorter and are zero-padded to it; `other` payloads are
+// taken verbatim and so must match it exactly.
 const MEMO_PAYLOAD_SIZE = 32
 
 const DASH = 100_000_000_000n
@@ -62,6 +64,7 @@ describe('ShieldedMemo', function () {
 
       expect(memo).toBeInstanceOf(ShieldedMemoWASM)
       expect(memo.toBytes().length).toEqual(36) // on-wire memo size
+      expect(memo.toString()).toEqual('')
     })
   })
 
@@ -72,11 +75,41 @@ describe('ShieldedMemo', function () {
 
       expect(memo).toBeInstanceOf(ShieldedMemoWASM)
       expect(memo.toBytes().length).toEqual(36)
-      expect(memo.toString().endsWith(text)).toBe(true)
+      expect(memo.toString()).toEqual(text)
     })
 
-    test('should reject a payload that is not 32 bytes', function () {
-      expect(() => ShieldedMemoWASM.fromString('too short')).toThrow()
+    test('should accept text shorter than the payload', function () {
+      const text = 'thanks for lunch' // 16 bytes, half the payload
+      const memo = ShieldedMemoWASM.fromString(text)
+      const bytes = memo.toBytes()
+
+      // The wire memo stays a fixed 36 bytes: a 4-byte little-endian kind tag
+      // (1 = text), the utf-8 text, then zero padding out to the 32-byte
+      // payload. The padding is not part of the decoded text.
+      expect(bytes.length).toEqual(36)
+      expect(Array.from(bytes.slice(0, 4))).toEqual([1, 0, 0, 0])
+      expect(new TextDecoder().decode(bytes.slice(4, 4 + text.length))).toEqual(text)
+      expect(bytes.slice(4 + text.length).every((byte) => byte === 0)).toBe(true)
+      expect(memo.toString()).toEqual(text)
+    })
+
+    test('should accept an empty string', function () {
+      const memo = ShieldedMemoWASM.fromString('')
+
+      expect(memo.toBytes().length).toEqual(36)
+      expect(memo.toString()).toEqual('')
+    })
+
+    test('should count multi-byte characters by their utf-8 byte length', function () {
+      // 8 x U+1F355 = 32 bytes, exactly the payload; 9 would be 36 bytes.
+      const memo = ShieldedMemoWASM.fromString('🍕'.repeat(8))
+
+      expect(memo.toString()).toEqual('🍕'.repeat(8))
+      expect(() => ShieldedMemoWASM.fromString('🍕'.repeat(9))).toThrow()
+    })
+
+    test('should reject text longer than 32 bytes', function () {
+      expect(() => ShieldedMemoWASM.fromString('A'.repeat(MEMO_PAYLOAD_SIZE + 1))).toThrow()
     })
   })
 

--- a/tests/unit/StateTransitionFees.spec.ts
+++ b/tests/unit/StateTransitionFees.spec.ts
@@ -1,0 +1,177 @@
+import {
+  AssetLockProofWASM,
+  BatchTransitionWASM,
+  CoreScriptWASM,
+  DataContractCreateTransitionWASM,
+  DataContractWASM,
+  IdentityCreateTransitionWASM,
+  IdentityCreditTransferWASM,
+  IdentityCreditWithdrawalTransitionWASM,
+  IdentityPublicKeyInCreationWASM,
+  IdentityTopUpTransitionWASM,
+  IdentityUpdateTransitionWASM,
+  KeyType,
+  OutPointWASM,
+  Purpose,
+  SecurityLevel,
+  StateTransitionWASM
+} from 'pshenmic-dpp'
+
+// Min fees from the platform fee version (STATE_TRANSITION_MIN_FEES_VERSION1)
+const CREDIT_TRANSFER_COST = BigInt(100000)
+const CREDIT_WITHDRAWAL_COST = BigInt(400000000)
+const IDENTITY_UPDATE_COST = BigInt(100000)
+const CONTRACT_CREATE_COST = BigInt(100000)
+const DOCUMENT_BATCH_SUB_TRANSITION_COST = BigInt(100000)
+const IDENTITY_CREATE_BASE_COST = BigInt(2000000)
+const IDENTITY_KEY_IN_CREATION_COST = BigInt(6500000)
+const IDENTITY_TOPUP_BASE_COST = BigInt(500000)
+// required asset lock duff balance × CREDITS_PER_DUFF (1000)
+const IDENTITY_CREATE_ASSET_LOCK_COST = BigInt(200000) * BigInt(1000)
+const IDENTITY_TOPUP_ASSET_LOCK_COST = BigInt(50000) * BigInt(1000)
+
+// A signed document batch transition holding a single document create transition
+const BATCH_TRANSITION_BASE64 = 'AgHv88sfWzscuW2Ob/0v5d+EgqmWG7ZIvlQG7mHWBH7z9gEAAAAB7JH7W+JkM0Vne2U1zlWYVeQNzRPTpdiWRfsgfwNS2UoCCGJsb2dQb3N0KBdMgeznVQ1smUXVFNPfE2PC379wpWVH8cdu2ilzeI0Ah/i2xfrKCm5ACQAbEQkSc+GRUkdLor4Eu7Vzf6oRc9UHBmJsb2dJZAogdhC4nVm3ufPCgdfoOKXtnhqwg7O3axyTS9WB3EFvNBYPY29tbWVudHNFbmFibGVkEwEHY29udGVudAr7AUh4nM2TTWrDMBCFrxK0jkCyJMvqLnRV6A1KFhpplJgotrEVaAi+e8clpdBuvCnNcn7ezPvQ6O3G2siemKgNSGETT8ZarhUm7hpX8yStEpVCk6xlW1auA1L34Ed/GP1wpNQw9sPEnm6s4Ht57nM/UkPE5C+5UBl8OB3G/tLF37VFscvtoTtjV6iSMRU2b1nou/KZIXf3jUvrXUHRrosbv8ltKRk30JbNl2LLpnLNuPiZ5z1NOrY5jtjRqP28vbM656zTleagJHCNXnIQiUIpgozGg2/0N2s4Yji9tlN5KXj+A97FJG1AcpZ8nnANv1wHGo22ASrFXQDJde0SBzDIdQBVRQEoDDw2aLUONPkKtfF0s9bR9bqGkJW3PNYCg/FOgIqPDarWgQrRxKapBXdCJ3pR7TjUVnJrpAo6yhSc/4dv+tPu/gNBt2qtC3B1Ymxpc2hlZEF0Av0AAAGcptJlIwRzbHVnEhV0aGlzLWlzLW15LWZpcnN0LXBvc3QIc3VidGl0bGUSD1dpdGggYSBzdWJ0aXRsZQV0aXRsZRIVVGhpcyBpcyBteSBmaXJzdCBwb3N0AAABQR+H40MbUEmFXQbTPcwy9vMD8EiTwDzMpW3YIkfSIDvHij5ZIAVvqm0ZJScJzKV7EnRUi/f1tZ/wFJfd1+LDtpps'
+
+function randomBytes (length: number): Uint8Array {
+  const bytes = new Uint8Array(length)
+  for (let i = 0; i < length; i++) {
+    bytes[i] = Math.floor(Math.random() * 256)
+  }
+  return bytes
+}
+
+function createTestKey (): IdentityPublicKeyInCreationWASM {
+  return new IdentityPublicKeyInCreationWASM(
+    0,
+    Purpose.AUTHENTICATION,
+    SecurityLevel.MASTER,
+    KeyType.ECDSA_SECP256K1,
+    false,
+    randomBytes(33)
+  )
+}
+
+function createAssetLockProof (): AssetLockProofWASM {
+  return AssetLockProofWASM.createChainAssetLockProof(100, new OutPointWASM('a'.repeat(64), 0))
+}
+
+describe('IdentityCreditTransferTransition fees', function () {
+  test('calculateMinRequiredFee should return the credit transfer min fee', function () {
+    const transition = new IdentityCreditTransferWASM(
+      randomBytes(32), BigInt(100000), randomBytes(32), BigInt(1)
+    )
+
+    expect(transition.calculateMinRequiredFee()).toEqual(CREDIT_TRANSFER_COST)
+  })
+})
+
+describe('IdentityCreditWithdrawalTransition fees', function () {
+  test('calculateMinRequiredFee should return the credit withdrawal min fee', function () {
+    const transition = new IdentityCreditWithdrawalTransitionWASM(
+      randomBytes(32),
+      BigInt(1000000),
+      1,
+      'Standard',
+      BigInt(1),
+      CoreScriptWASM.newP2PKH(randomBytes(20))
+    )
+
+    expect(transition.calculateMinRequiredFee()).toEqual(CREDIT_WITHDRAWAL_COST)
+  })
+})
+
+describe('IdentityUpdateTransition fees', function () {
+  test('calculateMinRequiredFee should return the identity update min fee', function () {
+    const transition = new IdentityUpdateTransitionWASM(
+      randomBytes(32), BigInt(1), BigInt(1), [createTestKey()], []
+    )
+
+    expect(transition.calculateMinRequiredFee()).toEqual(IDENTITY_UPDATE_COST)
+  })
+})
+
+describe('IdentityCreateTransition fees', function () {
+  test('calculateMinRequiredFee should price the base cost, asset lock and keys', function () {
+    const transition = new IdentityCreateTransitionWASM([createTestKey()], createAssetLockProof())
+
+    expect(transition.calculateMinRequiredFee()).toEqual(
+      IDENTITY_CREATE_BASE_COST + IDENTITY_CREATE_ASSET_LOCK_COST + IDENTITY_KEY_IN_CREATION_COST
+    )
+  })
+
+  test('calculateMinRequiredFee should grow with the key count', function () {
+    const oneKey = new IdentityCreateTransitionWASM([createTestKey()], createAssetLockProof())
+    const twoKeys = new IdentityCreateTransitionWASM(
+      [createTestKey(), createTestKey()], createAssetLockProof()
+    )
+
+    expect(twoKeys.calculateMinRequiredFee() - oneKey.calculateMinRequiredFee())
+      .toEqual(IDENTITY_KEY_IN_CREATION_COST)
+  })
+})
+
+describe('IdentityTopUpTransition fees', function () {
+  test('calculateMinRequiredFee should price the base cost and the asset lock', function () {
+    const transition = new IdentityTopUpTransitionWASM(createAssetLockProof(), randomBytes(32))
+
+    expect(transition.calculateMinRequiredFee())
+      .toEqual(IDENTITY_TOPUP_BASE_COST + IDENTITY_TOPUP_ASSET_LOCK_COST)
+  })
+})
+
+describe('BatchTransition fees', function () {
+  test('calculateMinRequiredFee should price each sub transition', function () {
+    const batch = BatchTransitionWASM.fromStateTransition(
+      StateTransitionWASM.fromBase64(BATCH_TRANSITION_BASE64)
+    )
+
+    expect(batch.calculateMinRequiredFee())
+      .toEqual(DOCUMENT_BATCH_SUB_TRANSITION_COST * BigInt(batch.transitions.length))
+  })
+})
+
+describe('StateTransition fees', function () {
+  test('calculateMinRequiredFee should match the concrete transition', function () {
+    const transition = new IdentityCreditTransferWASM(
+      randomBytes(32), BigInt(100000), randomBytes(32), BigInt(1)
+    )
+
+    expect(transition.toStateTransition().calculateMinRequiredFee())
+      .toEqual(transition.calculateMinRequiredFee())
+  })
+
+  test('calculateMinRequiredFee should work for a deserialized transition', function () {
+    const stateTransition = StateTransitionWASM.fromBase64(BATCH_TRANSITION_BASE64)
+
+    expect(stateTransition.calculateMinRequiredFee())
+      .toEqual(DOCUMENT_BATCH_SUB_TRANSITION_COST)
+  })
+})
+
+describe('DataContractCreateTransition fees', function () {
+  const OWNER_ID_BASE58 = 'HEAmUtC72dPcZ59yyLUgfS8pfrEWqzYfDPzTofgWxXRr'
+  const DOCUMENT_SCHEMA = {
+    note: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          position: 0
+        }
+      },
+      additionalProperties: false
+    }
+  }
+
+  test('calculateMinRequiredFee should cover the base fee plus the registration cost', function () {
+    const contract = new DataContractWASM(
+      OWNER_ID_BASE58, BigInt(1), DOCUMENT_SCHEMA, undefined, undefined, true
+    )
+    const transition = new DataContractCreateTransitionWASM(contract, BigInt(1))
+
+    expect(transition.calculateMinRequiredFee()).toBeGreaterThanOrEqual(CONTRACT_CREATE_COST)
+    expect(transition.calculateMinRequiredFee())
+      .toEqual(transition.toStateTransition().calculateMinRequiredFee())
+  })
+})


### PR DESCRIPTION
# Issue
dash-wallet-desktop require methods which allows to calculate platform fee and dpp provide this info. 
Also we need to add windows build support

# Things done
- Implemented methods for state transitions which allows to get fee or calculate fee 
- Added windows build
- fixed shielded memo size
- bump package version